### PR TITLE
Enforce sequential planning pipeline + action-oriented learnings

### DIFF
--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -541,7 +541,9 @@ Gather ALL actionable improvements from Steps 3 through 8 (standard findings, de
 Which should we proceed with? (I recommend executing all High priority items.)"
 ```
 
-**Key**: Present codebase and plugin items separately — the user may want to execute codebase items immediately but batch plugin items into a single PR. Ask the user for their preferred execution strategy before starting.
+**Key**: Present codebase and plugin items separately — but **default to executing both**. Do not defer plugin improvements to "next time" or "when you next improve the playbook." The whole point of the learnings phase is to close the loop in this session.
+
+**Default execution strategy**: Execute codebase improvements immediately, then locate the plugin repo and make plugin edits in the same session. Only defer if the user explicitly asks to skip plugin work. If you find yourself writing "these are documented in the learnings doc for when you next improve the playbook" — stop. That means you're deferring instead of executing.
 
 #### 9.1b: Systemic Analysis — Think Bigger (Project Completion Only)
 

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/product-requirements.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/product-requirements.md
@@ -20,6 +20,7 @@ What type of work is this?
    Examples: new page, new integration, new data model, new user flow
    → Full pipeline: PRD → Tech Plan → Tasks → Work → Learnings
    → **If UI-heavy**: PRD → Design System → Design Spec → Mockups → Design Critique → Tech Plan → Tasks → Work → Design Verify → Learnings
+   → **CRITICAL**: Each planning doc must be written SEQUENTIALLY (PRD, then tech plan, then tasks). Never write tech plan and tasks in parallel — tasks must derive from the tech plan's decisions.
 
 2. **UI polish / iteration** — Known scope, feedback-driven, just needs execution
    Examples: spacing fixes, animation tweaks, responsive adjustments, copy changes

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/tasks.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/tasks.md
@@ -34,11 +34,18 @@ Before starting, search for existing project documentation:
 
 Use Glob -> Grep -> Read strategy to find and incorporate relevant context.
 
-## Prerequisites
+## Prerequisites (Hard Gate)
 
 Before starting, ensure:
 - Tech Plan Document exists and is reviewed
 - User understands the technical architecture and sequencing
+
+**CRITICAL — Sequential Pipeline Enforcement:**
+This command must NOT run until the tech plan is fully drafted and reviewed. The pipeline is strictly sequential: **PRD → Tech Plan → Tasks**.
+
+- **Do NOT write tasks in parallel with the tech plan.** Task-level details (file paths, line numbers, exact code changes) must derive from the tech plan's architecture decisions. Writing them simultaneously causes contradictions — e.g., the tech plan says "use approach A" but tasks independently assume "approach B."
+- **Read the tech plan thoroughly before drafting any tasks.** Copy specific decisions (component names, API patterns, data models) verbatim from the tech plan rather than paraphrasing. Paraphrasing introduces drift.
+- If the tech plan doesn't exist yet, stop and run `/playbook:tech-plan` first. Do not proceed without it.
 
 ## Process
 

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/tech-plan.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/tech-plan.md
@@ -105,11 +105,18 @@ Grep: "module: [module-name]" in docs/
 
 Review any relevant learnings before making architectural decisions. Prior solutions may inform current approach.
 
-## Prerequisites
+## Prerequisites (Hard Gate)
 
 Before starting, ensure:
 - Product Requirements Document exists and is reviewed
 - User understands the high-level solution vision from Product Requirements
+
+**CRITICAL — Sequential Pipeline Enforcement:**
+The planning pipeline is strictly sequential: **PRD → Tech Plan → Tasks**. Each document must be fully drafted and reviewed before the next one begins.
+
+- **Do NOT write the tech plan and tasks document in parallel.** Tasks must derive from the tech plan's architecture decisions — writing them simultaneously causes contradictions (e.g., different URL construction strategies, conflicting line number references).
+- **Do NOT start the tech plan before reading the PRD.** The PRD defines what to build; the tech plan defines how. Skipping the PRD leads to architecture that doesn't match requirements.
+- If the user asks you to "write all the planning docs," still write them sequentially — PRD first, then tech plan, then tasks. Speed comes from concise writing, not parallel drafting.
 
 ## Process
 


### PR DESCRIPTION
## Summary
- Adds hard gates to `tech-plan.md` and `tasks.md` requiring sequential execution (PRD → Tech Plan → Tasks)
- Adds sequential pipeline note to `product-requirements.md` full pipeline description
- Updates `learnings.md` to default to executing plugin improvements immediately rather than deferring

## Context
Found during the forgot-password project retrospective (2026-04-05):

**Sequential planning**: The agent wrote the tech plan and tasks doc in parallel. This caused a contradiction between them (different `redirectTo` URL construction strategies) that was only caught by the critique phase. Tasks should derive from the tech plan, not be independently invented.

**Action-oriented learnings**: The learnings phase produced documentation (CLAUDE.md rules, learnings doc) but deferred all plugin improvements with "documented for when you next improve the playbook." The user explicitly asked for the learnings phase to default to concrete action.

## Changes
| File | Change |
|------|--------|
| `tech-plan.md` | Added "Sequential Pipeline Enforcement" hard gate in Prerequisites |
| `tasks.md` | Added "Sequential Pipeline Enforcement" hard gate in Prerequisites |
| `product-requirements.md` | Added CRITICAL note about sequential pipeline in full pipeline description |
| `learnings.md` | Changed default execution strategy from "ask preference" to "execute both targets" |

## Test plan
- [ ] Run `/playbook:tech-plan` on a new project — verify it reads PRD before drafting
- [ ] Run `/playbook:tasks` — verify it reads tech plan before drafting
- [ ] Run `/playbook:learnings` at project end — verify it locates plugin repo and proposes edits (not just docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)