### PR TITLE
feat: add Step 0 observability check to debug workflow

### DIFF
--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/debug.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/debug.md
@@ -61,6 +61,20 @@ Before starting, ensure:
 
 ## Process
 
+### Step 0: Check Observability Before Hypothesizing
+
+**Before forming any hypothesis about the root cause, check available observability sources for direct evidence.** The most common debugging waste is implementing a fix for a guessed root cause when 30 seconds of checking logs would reveal the actual error.
+
+Check whichever of these are available for the project:
+
+1. **Traces/APM**: LangSmith, Datadog, or equivalent — look for the actual error message, stack trace, and timing
+2. **Error tracking**: PostHog, Sentry, or equivalent — check for error events, frequency, and affected users
+3. **Deployment logs**: Railway, Vercel (`vercel logs`), CloudWatch — read the actual error output
+4. **CI/Actions history**: GitHub Actions run logs — check the actual failure output, not just the job name
+5. **Environment config**: Verify required env vars exist in the target environment (`vercel env ls`, `doppler secrets`, `railway variables`)
+
+**Rule**: Never change code based on an unverified hypothesis. If you catch yourself thinking "it's probably X," stop and find evidence first. State what you checked and what you found before proposing any fix.
+
 ### Step 0.5: Triage — Is This Related to Current Changes?
 
 **For CI/test failures or issues discovered during development:**


### PR DESCRIPTION
## Summary

- Adds a new "Step 0: Check Observability Before Hypothesizing" to the `/playbook:debug` workflow
- Requires agents to check available observability sources (LangSmith, PostHog, logs, CI history, env vars) before forming any hypothesis about root cause

## Motivation

Found in 3 separate project retrospectives in the Chef Chopsky project:
- **Preview env retro (2026-04-10)**: Agent hypothesized a timeout issue and changed code, when LangSmith traces showed the actual error was a missing database table (1s response, not a timeout)
- **Forgot-password retro (2026-04-05)**: Agent added 4 rounds of diagnostic logging instead of first checking `vercel env ls` for a missing `RESEND_API_KEY`
- **Pattern**: Agent acts on unverified hypothesis → wastes effort → user redirects to check evidence → evidence reveals actual cause in seconds

## Changes

`plugins/product-playbook-for-agentic-coding/commands/workflows/debug.md`:
- Added Step 0 before existing Step 0.5 (Triage)
- Lists 5 observability sources to check (traces, error tracking, logs, CI, env config)
- Emphasizes: "Never change code based on an unverified hypothesis"

## Test plan

- [ ] Run `/playbook:debug` on a test issue and verify Step 0 is followed before hypothesis formation

🤖 Generated with [Claude Code](https://claude.com/claude-code)