### PR TITLE
feat(workflows): apply agent-activity-ux retro learnings

### DIFF
--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/emergent.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/emergent.md
@@ -1,0 +1,93 @@
+---
+name: playbook:emergent
+description: Capture emergent in-flight scope (user-reported bug or new requirement mid-project) as a micro-PRD before implementing
+argument-hint: "<one-line summary>"
+---
+
+# Emergent Scope: Micro-PRD
+
+You are facilitating a **lightweight, in-flight capture** of scope that was not in the original PRD. The goal is to get just enough on paper that the implementation, tests, and learnings stay legible later — without slowing the user's momentum.
+
+## When to use
+
+Run this command when, mid-project, the user reports something the original PRD/tech-plan did not cover:
+
+- A production bug they want fixed in this branch
+- A new requirement that surfaced from real usage
+- A scope expansion that "feels obviously right" but wasn't planned
+
+The agent-activity-ux project (2026-04-24) shipped Wave 3 (`delete_recipe` tool + multi-action prompt rules) with no PRD or integration test. It worked, but the absence left a gap when later sessions tried to understand *why* the rules existed. This command is the cheap retroactive cure.
+
+## What this command produces
+
+A short markdown file at `projects/[status]/[project-name]/emergent/[short-name].md` with these sections — and ONLY these sections. Do not pad. Do not generate boilerplate.
+
+```markdown
+---
+name: <short-name>
+date: <YYYY-MM-DD>
+trigger: <bug-report | new-requirement | scope-expansion>
+linked-pr: <PR number, if known>
+linked-tasks: <task IDs from tasks.md, if any>
+---
+
+# <Title>
+
+## Trigger
+<One paragraph: what the user said, what they observed, why this surfaced now.>
+
+## Decision
+<2–4 bullets: what we are doing about it. Be specific — name files, tools, prompt rules, API changes.>
+
+## Test
+<Single bullet: how we will verify this in code (integration test name, E2E spec, manual probe). If "manual only", explicitly say so and explain why automation is deferred.>
+
+## Out of scope
+<Bullets for things the user might assume are included but aren't. Skip if N/A.>
+```
+
+## Process
+
+### Step 1 — Restate the trigger
+
+Echo back to the user what you heard, in 2–3 sentences. Get explicit confirmation before writing anything. Misstatements at this step propagate into the doc.
+
+### Step 2 — Propose the decision
+
+Draft the **Decision** bullets and present them to the user. Do not implement yet. The point of this command is to confirm the *what* before the *how*.
+
+### Step 3 — Identify the test
+
+Before agreeing on a decision, name the test that will catch a regression. If you cannot name a test, that is itself a finding — push back on the user before proceeding. The agent-activity-ux retro flagged "no integration test" as a process miss; this step closes the gap.
+
+### Step 4 — Write the doc
+
+Write the file using the template above. Keep it under one screen. If a section runs long, that is signal it belongs in the original PRD/tech-plan, not here.
+
+### Step 5 — Update `project-state.md`
+
+Add a single line under "Emergent scope" in `projects/[status]/[project-name]/project-state.md`:
+
+```markdown
+- <date>: <short-name> — <one-line summary>. See `emergent/<short-name>.md`.
+```
+
+### Step 6 — Hand off to implementation
+
+Tell the user: *"Micro-PRD captured at `<path>`. Ready to implement?"* Wait for explicit go-ahead before changing code.
+
+## What this command is NOT
+
+- **Not a substitute for `/playbook:product-requirements`** for net-new features. If the emergent scope is large enough to need a tech plan or critique, escalate — recommend a real PRD instead of this micro-PRD.
+- **Not a license to skip tests.** The Test section is required, not optional. If the user explicitly authorizes manual-only verification, document the *reason* in that bullet.
+- **Not retroactive.** If the emergent work is already shipped, capture it as a learnings entry, not a micro-PRD.
+
+## Example
+
+**User:** "Hey, the agent can't delete recipes mid-conversation — when I ask it to remove one, it just edits the existing one. Can we fix this?"
+
+**Agent (after Step 1–3):**
+- Trigger: User cannot delete recipes via chat. Production bug observed in 3 chats today.
+- Decision: (1) Add `delete_recipe` tool to agent. (2) Update prompt rules to allow multi-action turns (create + edit + delete). (3) Update `getToolDisplayName`/`getClientToolSummary` for the new tool.
+- Test: New integration test `agent/tests/integration/delete-recipe.test.ts` covering create-then-delete in a single turn.
+- Out of scope: Bulk deletion UI, undo, soft-delete semantics.

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -95,11 +95,18 @@ Unimplemented improvement ideas from prior retrospectives:
 
 **Run a planned-vs-implemented gap analysis before the retrospective.** This gives the retrospective concrete data instead of relying on memory.
 
-1. **Locate planning docs**: Find the PRD, tech plan, tasks doc, and any v2/revised plans
-2. **Compare planned vs actual**: For each planned component, check if it was implemented, modified, deferred, or dropped
-3. **Write the analysis to a file**: Save as `projects/[project-name]/planned-vs-implemented.md` — this becomes input to the retrospective questions
+1. **Locate planning docs**: Find the PRD, tech plan, tasks doc, and any v2/revised plans.
+2. **Query authoritative sources, do NOT infer**:
+   - **PR state**: Use `gh pr view <number> --json state,isDraft,createdAt,mergedAt,mergeCommit,additions,deletions,changedFiles,commits` (or `gh pr list --search "head:<branch>"` if no number is known). Do not infer "no PR exists" from the absence of a feature branch — draft PRs and squash-merged branches both look like nothing locally.
+   - **Commits**: `git log --oneline <base>..<head>` against the actual base branch the PR targeted (read it from `gh pr view`, do not assume `main`).
+   - **File scope**: `git diff --stat <base>..<head>` for the real change footprint.
+   - For squash-merged PRs, use `gh pr view --json mergeCommit` to find the squash commit on the base branch.
+3. **Compare planned vs actual**: For each planned component, check if it was implemented, modified, deferred, or dropped.
+4. **Write the analysis to a file**: Save as `projects/[project-name]/planned-vs-implemented.md` — this becomes input to the retrospective questions.
 
 **Why this matters**: Without a gap analysis, retrospective questions like "what didn't work?" get vague answers. With a gap analysis, you can ask specific questions like "the tech plan called for GitHub Actions but you used local cron — what drove that decision?"
+
+**Why the `gh pr view` step is required**: The agent-activity-ux retro (2026-04-24) initially asserted "No PR exists after 17 days" — wrong, the PR had been a draft from day 2 and was merged on the same day as the retro. The error came from inferring PR state from local git only. `gh pr view` is the cheap, authoritative cure.
 
 #### Pre-Check B: Validation Tasks
 
@@ -507,6 +514,29 @@ Implement all approved edits after a single approval. Do not ask per-item.
 - [ ] **Are planning docs still accurate?** If the project evolved beyond the original tech plan or tasks doc, mark stale docs as superseded with a deprecation notice pointing to the current source of truth.
 - [ ] **Are there standalone critique/review docs that were never referenced?** Synthesize key warnings into the tasks doc as inline notes, then consider archiving the standalone files to reduce directory noise.
 - [ ] **Does an architecture README exist?** If agents spent significant time re-discovering the codebase structure, create or update a README in the relevant directory. This is the single highest-ROI action for multi-session projects.
+
+#### Step 7b: Loose Artifacts Sweep
+
+Multi-week generative projects accumulate untracked artifacts: design exploration screenshots, draft HTML comparison files, side-by-side prototypes, intermediate analysis docs. The agent-activity-ux retro (2026-04-24) found 9 such files dangling in `projects/in-progress/` — useful work that was never tied back to the project's history.
+
+**Run this sweep before declaring the retrospective complete:**
+
+```bash
+# 1. List untracked or untracked-but-modified files in the project directory
+git status --porcelain projects/[status]/[project-name]/
+
+# 2. List untracked files anywhere that look related (loose screenshots, HTMLs)
+git ls-files --others --exclude-standard | grep -iE "[project-keyword]" || true
+```
+
+For each file the sweep returns, decide:
+- **Commit it** alongside the retro if it informed a decision or shows an alternative considered (variant exploration, before/after screenshots, side-by-side comparisons). Move into `projects/[status]/[project-name]/` if it lives elsewhere.
+- **Delete it** if it was an intermediate scratch artifact with no ongoing value.
+- **Move it** into `docs/learnings/assets/` if it has cross-project value (a generic pattern, a reusable diagram).
+
+Do NOT leave files dangling. Either it's worth keeping (so commit it where future-you will find it) or it isn't (so remove it). The mid-state — in the working tree, untracked, undocumented — is the worst outcome.
+
+This sweep is mandatory for **deep** project-completion retros. For incident retros and lighter triggers, skim and skip if nothing turns up.
 
 ### Step 8: Validate Completeness
 

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/tasks.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/tasks.md
@@ -36,15 +36,17 @@ Use Glob -> Grep -> Read strategy to find and incorporate relevant context.
 
 ## Prerequisites (Hard Gate)
 
-Before starting, ensure:
-- Tech Plan Document exists and is reviewed
+Before starting, ensure ALL of the following exist:
+- **Tech Plan Document** exists and is reviewed
+- **Critique synthesis** exists alongside the tech plan (e.g., `critique.md`, `critique-tech-plan.md`, or a "Critique findings" section in the tech plan itself). This is the output of `/playbook:critique` run on the tech plan.
 - User understands the technical architecture and sequencing
 
 **CRITICAL — Sequential Pipeline Enforcement:**
-This command must NOT run until the tech plan is fully drafted and reviewed. The pipeline is strictly sequential: **PRD → Tech Plan → Tasks**.
+This command must NOT run until the tech plan is fully drafted, reviewed, AND critiqued. The pipeline is strictly sequential: **PRD → Tech Plan → Critique → Tasks**.
 
 - **Do NOT write tasks in parallel with the tech plan.** Task-level details (file paths, line numbers, exact code changes) must derive from the tech plan's architecture decisions. Writing them simultaneously causes contradictions — e.g., the tech plan says "use approach A" but tasks independently assume "approach B."
-- **Read the tech plan thoroughly before drafting any tasks.** Copy specific decisions (component names, API patterns, data models) verbatim from the tech plan rather than paraphrasing. Paraphrasing introduces drift.
+- **Do NOT skip the critique.** If you cannot find a critique synthesis file or section in the project directory, STOP and run `/playbook:critique` first. The agent-activity-ux retro (2026-04-24) traced ~1 day of architectural rework directly to a skipped critique. This gate exists to close that gap.
+- **Read the tech plan AND critique thoroughly before drafting any tasks.** Copy specific decisions (component names, API patterns, data models) verbatim from the tech plan rather than paraphrasing. Paraphrasing introduces drift. Note any critique findings the tasks must reflect.
 - If the tech plan doesn't exist yet, stop and run `/playbook:tech-plan` first. Do not proceed without it.
 
 ## Process

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/tech-plan.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/tech-plan.md
@@ -165,6 +165,7 @@ Building before architecture is confirmed leads to wasted effort on unused code.
 1. Check if a Tech Plan document already exists for this project
 2. If not, use the template pattern from `resources/templates/tech-plan.md`
 3. Create it in an appropriate location (e.g., `projects/[project-name]/tech-plan.md`)
+4. **Also seed `project-state.md`** in the same project directory if it does not exist. This is the rolling state file that survives session/compaction boundaries (see `/playbook:work` Step 1b for the full pattern). Initial contents: a one-line link to this tech plan, the chosen architecture name/summary, and an empty "Open contracts" section. Do not skip — projects that lack this artifact pay 50–110× context-loss tax across sessions (see agent-activity-ux retro, 2026-04-24).
 
 ### Step 3: Facilitate Technical Planning
 
@@ -293,10 +294,15 @@ If the plan introduces shared infrastructure (libraries, runners, delivery mecha
 
 ## Next Steps
 
-Once the Tech Plan Document is complete, guide the user to:
-1. Review and validate the document
-2. **Run a stakeholder critique** — use `/playbook:critique` to get multi-persona feedback on the tech plan. Catching architectural issues before implementation is 10x cheaper than fixing them during delivery.
-3. Proceed to Delivery phase using `/playbook:tasks`
+Once the Tech Plan Document is complete, **STOP** and guide the user through these in order. Do not skip step 2.
+
+1. Review and validate the document.
+2. **MANDATORY: Run `/playbook:critique` before proceeding.** A multi-persona stakeholder critique on the tech plan is required, not optional. Catching architectural issues before implementation is ~10× cheaper than fixing them during delivery.
+   - Save the critique output as `critique.md` (or `critique-tech-plan.md`) alongside the tech plan.
+   - The next phase (`/playbook:tasks`) **gates on the existence of this file**.
+   - If the user asks to skip the critique, push back. Past retros (agent-activity-ux, 2026-04-24) showed that skipping `/playbook:critique` caused architectural rework worth ~1 day per skip. The rule that closes that gap is: critique is mandatory.
+3. Address critique findings in a revised tech plan **or** explicitly note in the critique synthesis which findings were considered and deferred.
+4. Proceed to Delivery phase using `/playbook:tasks`.
 
 ---
 

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/work.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/work.md
@@ -99,6 +99,21 @@ Before starting, ensure:
    - Has all dependencies satisfied
    - Is not blocked
 
+### Step 1b: Read or Create the Project State Artifact
+
+Multi-week projects almost always cross a session/compaction boundary. The agent-activity-ux retro (2026-04-24) measured 50–110× re-reads of the same files because no rolling artifact survived between sessions. Maintain a single project-state file so a fresh session can pick up without re-deriving context.
+
+1. **Locate** `projects/[status]/[project-name]/project-state.md`. If it does not exist, create it.
+2. **Read it before doing anything else** when starting a new session. It must contain (at minimum):
+   - **Architecture decisions**: What patterns were chosen, what was rejected, and why (one line each — link to tech plan / critique for full reasoning).
+   - **Current state**: Which tasks are done, which is in flight, what's blocked.
+   - **Open contracts**: testIDs, SSE event names, file-path conventions, anything multiple files reference.
+   - **Outstanding decisions**: Open questions awaiting user input.
+3. **Update it as you go.** When you make a non-trivial decision, when a task closes, when scope shifts — write a 1–3 line entry. Don't write prose; write an index. The body lives in PRD/tech-plan/tasks/critique.
+4. **Keep it under ~200 lines.** This is an index, not a wiki. If a section grows past 20 lines, it belongs in its own dedicated doc.
+
+This artifact is the single most effective intervention to combat cross-session context loss. Treat updates as part of the task, not as overhead.
+
 ### Step 1.5: Scope Verification (Every 3-5 Tasks)
 
 **From Engineering Manager perspective:**
@@ -220,6 +235,28 @@ npm test           # Unit tests (at minimum)
 
 **Timeout note**: If validation takes >2 minutes, run it with an explicit Bash timeout (e.g., `timeout: 300000`) to avoid Claude Code's default 120s timeout killing the process.
 
+#### 1b. testID / Test Selector Hygiene Check
+
+If the changes you made include **renaming, removing, or moving any test selectors** (testID, data-testid, aria-label used by tests, role-based selectors), you MUST verify the same commit also updates every test that references the old selector. Selector renames without same-commit test updates are the single most common cause of "tests sat broken for days" regressions — see the agent-activity-ux retro (2026-04-24) where a `assistant-thinking → thinking-row` rename broke 11 tests for 11 days.
+
+**Run before declaring the dry-run complete:**
+
+```bash
+# Did this change rename a testID? Check what changed.
+git diff --staged --diff-filter=M -- '*.tsx' '*.ts' | grep -E '^[-+].*testID|^[-+].*data-testid' || echo "no testID changes"
+
+# For every changed testID literal, find references in tests:
+# (replace OLD_NAME with the renamed value)
+grep -rln 'OLD_NAME' frontend/tests app/tests tests/ 2>/dev/null
+
+# If the project has a contract script, run it now:
+npm run check:testid-contracts 2>/dev/null || true
+```
+
+If you find references to the old selector, update them in this same commit. Do NOT push and rely on CI E2E to catch the regression — sharded E2E often runs after fast jobs and the failure surfaces hours later.
+
+**This rule applies to ANY test selector**, not just testIDs: aria-label values, role+name combinations, fixed text content used by `getByText`, etc.
+
 #### 2. Walk Through the Feature Yourself
 
 **For UI changes**: Launch the dev server and use browser tools to verify:
@@ -325,6 +362,25 @@ Before marking task complete, verify:
 - [ ] Quality checks passing
 - [ ] Documentation updated
 - [ ] Tasks Document updated
+
+#### Step 7b: Pre-Merge Hard Gate (Required Before PR Goes Out of Draft)
+
+When the **last task in the project** is complete and you (or the user) are about to mark the PR ready for review, run the project's **full** validation suite — not just `ci:local`. The agent-activity-ux retro (2026-04-24) caught a 4-commit fix-forward cascade after a testID rename that `ci:local` did not catch but `test:verify` would have.
+
+```bash
+# Discover the right command:
+#   1. Read CLAUDE.md / AGENTS.md / GEMINI.md for the project's pre-PR command
+#   2. Otherwise prefer test:verify > ci:local:full > test:full
+npm run test:verify    # runs lint + typecheck + unit + integration + E2E
+
+# If integration/E2E require services, the script should start them. If it
+# does not, start services explicitly first:
+npm run deploy:development:all &  # or the project-specific equivalent
+```
+
+**Do not push and rely on CI** to discover failures. CI failures arrive minutes-to-hours later and frequently mask each other (sharded E2E with `fail-fast: true` reports the first shard's failure and skips the rest, requiring multiple iterations to surface all problems). Local `test:verify` reports everything in one run.
+
+**If `test:verify` does not exist in this project**, propose adding it (see CLAUDE.md guidance) before marking the PR ready. Do not silently downgrade to `ci:local`.
 
 ## Task Execution Workflow
 


### PR DESCRIPTION
## Summary

P1–P5 plugin improvements from the chef-chopsky **agent-activity-ux** retrospective (2026-04-24). Each change addresses a pattern that's now appeared in 3+ retrospectives — documentation alone hasn't solved them.

- **`tech-plan.md`** — `/playbook:critique` is now a hard gate. Output must reference a critique synthesis FILE, not just recommend running it. (Wave 2 of agent-activity-ux skipped critique → "three mutually-exclusive render paths" pattern shipped → 1 day rework + 11-day testID cascade.)
- **`tasks.md`** — Tasks now require a critique synthesis file as a prerequisite. Pipeline is now PRD → Tech Plan → Critique → Tasks.
- **`work.md`** — Adds Step 1b (project-state.md rolling artifact for cross-session/cross-wave context — answers "files re-read 50–110× per file"), Step 5.5 sub-section 1b (testID/test-selector hygiene check), and Step 7b (Pre-Merge Hard Gate: `test:verify` must pass before PR ready).
- **`emergent.md`** (new) — `/playbook:emergent` command for emergent-scope micro-PRDs. Wave 3 of agent-activity-ux shipped `delete_recipe` with no PRD/tasks/integration test; this codifies the lightweight pattern instead of skipping process entirely.
- **`learnings.md`** — Pre-Check A now mandates `gh pr view` for PR state (the original `planned-vs-implemented.md` inferred PR state from local commits and got it wrong). Step 7b adds a loose-artifacts sweep with bash commands.

Refs: chef-chopsky `docs/learnings/2026-04-24-agent-activity-ux-retrospective.md` (companion PR https://github.com/daviswhitehead/chef-chopsky/pull/259).

## Test plan

- [ ] Self-review the changes for clarity and consistency with surrounding workflow files
- [ ] Validate `emergent.md` frontmatter renders correctly when invoked as `/playbook:emergent`
- [ ] Dogfood: use the new `tech-plan.md` critique-as-file gate on the next planning session and confirm it triggers
- [ ] Dogfood: invoke `/playbook:emergent` for the next emergent-scope task to validate the template

🤖 Generated with [Claude Code](https://claude.com/claude-code)