### PR TITLE
improve(close,learnings): branch-state pre-check + CLAUDE.md size pre-flight

### DIFF
--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
@@ -12,11 +12,18 @@ You are facilitating an end-of-session close-out. Run each phase in order. Skip 
 
 ## Phase 1: Uncommitted Work Check
 
-1. Run `git status`.
-2. If there are uncommitted changes:
+1. **Branch state check (do first)**: If the current branch's PR is already merged, new commits on this branch will NOT reach the target. Detection:
+   - `gh pr list --head $(git branch --show-current) --state merged --limit 1` (or check `git log <target>..HEAD` against a known squash-merge commit on the target).
+   - If merged, warn the user and offer to branch off the target before committing:
+     > "Current branch `<name>` is already merged into `<target>` (likely via squash). Any commits made here will be local-only. Want me to branch off `<target>` so the close-out commits reach production?"
+   - If the user approves, create a fresh branch off `origin/<target>` and continue close-out there. Cherry-pick later if needed.
+   - This catches the common case where a session continues *after* the main PR merges (close-out, follow-up docs, learnings). The skill previously assumed the current branch was always a valid commit target.
+
+2. Run `git status`.
+3. If there are uncommitted changes:
    - Show a brief summary (files changed, not full diffs)
    - Offer to commit. If the user approves, draft a commit message and commit.
-3. If the working tree is clean: skip silently.
+4. If the working tree is clean: skip silently.
 
 ## Phase 2: Task Cleanup
 

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -55,6 +55,30 @@ Before proceeding, consider what tools are available:
 
 ## Process
 
+### Pre-Check: CLAUDE.md Size Health (ALL Trigger Types)
+
+**Run this check at the very start**, alongside the prior learnings search. CLAUDE.md is loaded into every agent session, so size growth has compounding cost.
+
+1. Run `wc -c CLAUDE.md` (skip if no CLAUDE.md exists in the project).
+2. **If over 40,000 chars**: trimming is **mandatory** before this retrospective adds any new content. Past this point, CLAUDE.md degrades agent performance. Surface to the user immediately:
+
+   ```
+   CLAUDE.md is at <N> chars — over the 40,000 hard limit.
+   Trimming is required before this retrospective can promote new content.
+
+   Common demotion candidates:
+   - RESOLVED known issues → docs/learnings/resolved-issues.md
+   - Niche/domain-specific guides → docs/guides/[topic].md (keep 1-line ref)
+   - Stale file trees / "(NEW)" markers from past milestones
+   - Duplicated content across sections
+
+   Trim first, then continue the retrospective? Or surface specific candidates?
+   ```
+
+3. **If between 32,000 and 40,000 chars** (80% of limit): flag as approaching threshold but don't block. Note it in the prior-learnings summary so the user can choose to trim opportunistically during Step 6 (Promotion).
+
+**Why pre-flight, not just pre-promotion**: catching size violations before any other work means the user can decide to trim *first* and have a clean baseline. Discovering it mid-promotion (which is where the historical check lived) forces a context-switch when the retrospective should be wrapping up. The Step 6 health check remains as a backstop in case content is added during facilitation.
+
 ### Pre-Check: Prior Learnings Search (ALL Trigger Types)
 
 **Before starting any retrospective**, search for prior learnings to enable cross-session pattern detection:
@@ -452,16 +476,13 @@ If any items are unchecked, go back and address them before continuing.
 
 A learning left in a doc is a learning that will be re-learned the hard way. Promote findings via two parallel tracks.
 
-#### Pre-Promotion: CLAUDE.md Health Check
+#### Pre-Promotion: CLAUDE.md Health Check (Backstop)
 
-**Before adding content to CLAUDE.md**, check its current size:
-1. Run `wc -c CLAUDE.md`
-2. If over **32,000 chars** (80% of 40k limit), trim before adding:
-   - Archive RESOLVED known issues → `docs/learnings/resolved-issues.md`
-   - Move niche/domain-specific guides → `docs/guides/[topic].md` (keep 1-line reference)
-   - Remove content that duplicates the Quick Reference section
-   - Condense verbose sections to a reference + link
-3. If over **40,000 chars**, trimming is **mandatory** — the file will degrade agent performance
+The primary CLAUDE.md size check now runs in **Pre-Check: CLAUDE.md Size Health** at the start of the workflow. This step is a backstop in case content was added during Step 3 facilitation (e.g., new gotchas discovered mid-retrospective). Re-run `wc -c CLAUDE.md`; if it's grown past 40k since pre-flight, apply the same demotion guidance:
+- Archive RESOLVED known issues → `docs/learnings/resolved-issues.md`
+- Move niche/domain-specific guides → `docs/guides/[topic].md` (keep 1-line reference)
+- Remove content that duplicates the Quick Reference section
+- Condense verbose sections to a reference + link
 
 **Demotion checklist** (run before promotion):
 - [ ] Are there RESOLVED known issues still in CLAUDE.md? → Archive


### PR DESCRIPTION
## Summary

Two skill improvements discovered during a real session close-out (downstream PRs: [chef-chopsky #269](https://github.com/daviswhitehead/chef-chopsky/pull/269) → follow-up [#270](https://github.com/daviswhitehead/chef-chopsky/pull/270)).

### 1. `close.md` Phase 1 — branch state check

**Problem**: The skill instructs committing the checkpoint on the current branch unconditionally. After a squash-merge, the current branch is stale — its local commits never reach the target. In the session that produced this PR, the agent almost committed close-out work to a merged branch; only a manual diff caught it.

**Fix**: New first sub-step in Phase 1 that detects merged state via `gh pr list --head $(git branch --show-current) --state merged --limit 1` and offers to branch off the target before committing.

### 2. `learnings.md` — CLAUDE.md size health check pre-flight

**Problem**: The CLAUDE.md size check lived in Step 6 (Pre-Promotion). Discovering a size violation mid-flow forces a context switch when the retrospective should be wrapping up. In the session that produced this PR, the downstream CLAUDE.md crossed the 40k hard limit when the retrospective's GRANT section was added; only catching it during Step 6 meant trimming after most of the work was done.

**Fix**: Promoted the check to a Pre-Check (alongside prior-learnings search), so the user trims first and the retrospective proceeds with a clean baseline. Step 6 retained as a backstop in case content is added during facilitation.

## Why both in one PR

Both gaps surfaced in the same session — they're related polish on the close-out → learnings handoff and reviewing them together provides the same context. Each edit is ~10 lines.

## Test plan

- [ ] Read both edited files for clarity and ordering.
- [ ] Next real close-out / learnings session uses the new pre-checks. Watch for: does the branch-state check actually catch the case? Does the CLAUDE.md pre-flight surface size issues earlier than before?

The strongest verification is using the skill on a real session, which is exactly how these gaps were found.