### PR TITLE
improve(close,learnings): branch-state + CLAUDE.md size pre-flight checks

### DIFF
--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
@@ -12,12 +12,19 @@ You are facilitating an end-of-session close-out. Run each phase in order. Skip 
 
 ## Phase 1: Uncommitted Work Check
 
-1. **Branch state check (do first)**: If the current branch's PR is already merged, new commits on this branch will NOT reach the target. Detection:
+1. **Branch state check (do first)**: The current branch may not be a valid commit target for your close-out. Two common failure modes:
+
+   **(a) Branch is merged.** If the current branch's PR is already merged, new commits on this branch will NOT reach the target.
    - `gh pr list --head $(git branch --show-current) --state merged --limit 1` (or check `git log <target>..HEAD` against a known squash-merge commit on the target).
    - If merged, warn the user and offer to branch off the target before committing:
      > "Current branch `<name>` is already merged into `<target>` (likely via squash). Any commits made here will be local-only. Want me to branch off `<target>` so the close-out commits reach production?"
-   - If the user approves, create a fresh branch off `origin/<target>` and continue close-out there. Cherry-pick later if needed.
-   - This catches the common case where a session continues *after* the main PR merges (close-out, follow-up docs, learnings). The skill previously assumed the current branch was always a valid commit target.
+
+   **(b) Branch was changed by another agent (parallel-agent workspaces — Conductor, git worktrees, etc.).** If multiple agents share a working directory, the current branch may have been switched while you were sleeping/waiting on tools. Detection:
+   - `git branch --show-current` — does it match the branch *your* session has been working on? Compare against the branch you last pushed to, or the PR head you've been monitoring.
+   - If unfamiliar, ask the user before committing anywhere: it likely belongs to another agent's in-flight work.
+   - Stash any unrelated uncommitted changes (they may be the other agent's WIP) before switching back: `git stash push -m "other-agent-WIP" <paths>`. Restore after your work completes.
+
+   **In both cases**, if the user approves, create a fresh branch off `origin/<target>` and continue close-out there. Cherry-pick later if needed. The skill previously assumed the current branch was always a valid commit target — both (a) (session continues after the main PR merges — close-out, follow-up docs, learnings) and (b) (parallel agents) violate that assumption.
 
 2. Run `git status`.
 3. If there are uncommitted changes:

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -55,6 +55,17 @@ Before proceeding, consider what tools are available:
 
 ## Process
 
+### Pre-Check: Branch State (ALL Trigger Types)
+
+**Run this before any other pre-check.** A learnings retrospective ends with commits and a PR — both depend on the current branch being a valid target for *this* session's work. Two failure modes to detect upfront:
+
+1. **Branch is merged.** If the original PR was squash-merged, the local branch still exists but commits to it won't reach the target. Detect: `gh pr list --head $(git branch --show-current) --state merged --limit 1`. If a merged PR comes back, ask the user before committing:
+   > "Current branch `<name>` was merged via PR #<n>. Commits will be local-only. Branch off `<target>` first?"
+
+2. **Branch was switched by another agent (parallel-agent workspaces — Conductor, git worktrees).** If multiple agents share a working directory, your session's branch may have been switched while you were sleeping/awaiting tools. Detect: compare `git branch --show-current` against the branch your session has been working on (last push target, PR head being monitored). If it's unfamiliar, stash any unrelated uncommitted changes (`git stash push -m "other-agent-WIP" <paths>`) and create a fresh branch off the target before continuing. Restore the stash after.
+
+If `/playbook:learnings` was invoked from `/playbook:close`, the close skill's Phase 1 already runs an equivalent check — you can skip this. For standalone invocations or after long wait gaps, run it.
+
 ### Pre-Check: CLAUDE.md Size Health (ALL Trigger Types)
 
 **Run this check at the very start**, alongside the prior learnings search. CLAUDE.md is loaded into every agent session, so size growth has compounding cost.


### PR DESCRIPTION
## Summary

Two pre-flight gaps discovered across two real sessions of `/playbook:close` and `/playbook:learnings`:

### 1. Branch-state check before committing close-out / learnings (close.md, learnings.md)

A session continuing *after* its main PR merges (close-out, follow-up docs, learnings) tries to commit on a branch that's already merged. Local commits go nowhere. Caught in chef-chopsky PR #269 → follow-up #270.

A second variant: in **parallel-agent workspaces** (Conductor, git worktrees), another agent in the same working directory can switch the current branch while you're sleeping or awaiting tools. Same symptom (commits on wrong branch), different detection. Caught in chef-chopsky PR #267 (memory phase 2c.2) closeout — workspace shifted branches **twice** in one session while agents waited on CI.

Both variants now handled in `close.md` Phase 1 and `learnings.md` Pre-Check.

### 2. CLAUDE.md size health check moved earlier (learnings.md)

The health check used to live in Step 6 (Pre-Promotion). Adding new learnings content pushed CLAUDE.md over 40k chars mid-session — discovered at promotion time, forcing a context switch when the retrospective should have been wrapping up. Moved to Pre-Check alongside prior-learnings search so the user can trim first and proceed with a clean baseline. Step 6 retained as a backstop for content added during facilitation.

## Files changed

- `plugins/product-playbook-for-agentic-coding/commands/workflows/close.md` — Phase 1 branch-state check (merged-branch + parallel-agent variants).
- `plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md` — Pre-Check: Branch State + Pre-Check: CLAUDE.md Size Health (promoted from Step 6).

## Why these came up

Both gaps surfaced during real sessions, not theoretical review. The polish is discoverable mostly through use.

## Test plan

- [ ] Run `/playbook:close` on a session where the original PR was just merged → expect the branch-state check to fire and prompt before committing.
- [ ] Run `/playbook:learnings` standalone (not from `/playbook:close`) in a Conductor workspace where another agent has changed the branch → expect the parallel-agent branch-state check to fire.
- [ ] Run `/playbook:learnings` on a project where CLAUDE.md is >40k → expect the pre-flight trim prompt at the start, not at Step 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)