### PR TITLE
feat(monitor-pr): new /playbook:monitor-pr + learnings cross-repo URL + 32-40k band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`/playbook:monitor-pr`** — New autonomous PR-monitoring workflow. Watches CI to green, fixes failures locally first, and minimizes GitHub Actions minutes via a cost hierarchy (local validation > free rerun > expensive push). Codifies cache-friendly polling intervals, demote-and-re-promote for test/docs-only fixes, false-green sanity checks for path-filtered jobs, and `gh run rerun --failed` over empty-commit retriggers. Designed to be invoked after every PR submission as `/playbook:monitor-pr` (auto-detects PR from branch) or in a loop via `/loop /playbook:monitor-pr`.
+
+### Changed
+- **`/playbook:learnings` Step 9.3** — Plugin PR creation now requires a cross-repo URL resolution check: when the plugin PR description references codebase docs as evidence, those docs must be on the default branch before the plugin PR opens. If they only live on a feature branch, open a thin docs-only PR against the codebase first. Prevents dead-link reviewer friction observed in the 2026-05-18 memory-phase-2 close-out.
+- **`/playbook:learnings` Pre-Promotion check (32k–40k CLAUDE.md band)** — When CLAUDE.md is between the 32k soft limit and the 40k hard limit, the agent must surface the trim/defer-to-guides/skip decision explicitly with a recommendation, instead of silently choosing. Closes a meta-retrospective gap where the choice was being made without user visibility.
+
+### Why
+Captured during the 2026-05-18 memory-phase-2 2c.5–2c.8 close-out session (chef-chopsky PR #283). The user established a pattern of asking an agent to "monitor every PR autonomously while minimizing GitHub Actions minutes" — promoted from a repeated ad-hoc prompt to a first-class workflow. The two `learnings.md` changes came from the meta-retrospective on the same session.
+
 ## [0.19.0] - 2026-04-26
 
 ### Added

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -545,6 +545,23 @@ The primary CLAUDE.md size check now runs in **Pre-Check: CLAUDE.md Size Health*
 - [ ] Is any CLAUDE.md content duplicated across sections? → Consolidate
 - [ ] Are there stale milestone-specific references? → Delete
 
+**When CLAUDE.md is between 32k–40k chars — surface the trim/defer/skip decision explicitly:**
+
+Don't silently choose between trimming and skipping the CLAUDE.md addition. Surface the three options to the user with a recommendation:
+
+```
+CLAUDE.md is currently at <N> chars (over the 32k soft limit, under the 40k hard limit).
+
+I have three options for this finding:
+1. **Trim first** — apply the demotion checklist above, then add the new content (estimated ~10 min of doc surgery)
+2. **Defer to docs/guides/** — write the finding as `docs/guides/[topic].md`; rely on grep-discovery instead of CLAUDE.md (zero CLAUDE.md cost, but the agent has to find it on its own)
+3. **Skip** — the finding isn't important enough to warrant either option
+
+My recommendation: [option] because [rationale tying to finding severity + CLAUDE.md current state].
+```
+
+The recipes retrospective (2026-03-16) and the memory-phase-2 2c.5–2c.8 close-out (2026-05-18) both hit this case. Silent choice in either direction loses information — surfacing it lets the user weigh CLAUDE.md hygiene against discoverability for the specific finding.
+
 ---
 
 #### Track 1: Codebase Promotion
@@ -747,13 +764,28 @@ If the user selected "Both" or "Plugin/workflow" as the output target and improv
 1. **Locate the plugin repo**: Check `.claude/plugins/` for the plugin directory
 2. **Create a feature branch**: `git checkout -b improve/[project-name]-retrospective-learnings`
 3. **Make changes**: Modify the relevant plugin files (commands, templates, skills)
-4. **Create the PR**: Use `gh pr create` with a clear description of what was learned and why each change improves the workflow
-5. **Report the PR URL** to the user
+4. **Cross-repo URL resolution check** (see below) — if the plugin PR's description references codebase docs as evidence, those docs must be on the default branch BEFORE the plugin PR opens
+5. **Create the PR**: Use `gh pr create` with a clear description of what was learned and why each change improves the workflow
+6. **Report the PR URL** to the user
 
 **Common plugin files to improve:**
 - `commands/workflows/*.md` — Workflow steps and guidance
 - `resources/templates/*.md` — Task and document templates
 - `skills/*.md` — Skill definitions and patterns
+
+**Cross-repo URL resolution (load-bearing)**:
+
+When the plugin PR description cites a codebase learnings doc as evidence (typical for systemic-fix PRs grounded in a real incident), the doc URL like `https://github.com/<org>/<repo>/blob/<default-branch>/docs/learnings/<file>.md` will 404 if the doc only lives on a feature branch.
+
+**Before opening the plugin PR**, check:
+
+1. Are the cited codebase docs already on the project's default branch (`production` / `main`)? If yes — open the plugin PR as planned.
+2. If the docs only exist on a feature branch that hasn't merged yet, open a **thin docs-only PR** against the codebase repo FIRST. It typically runs only lint+typecheck+unit-tests (path-filtered jobs skip), so the CI cost is low (~12 min) and the URLs become durable.
+3. Only then open the plugin PR. The two PRs can review and merge in parallel.
+
+**Why this matters**: Reviewers of the plugin PR need to validate the premise (the real incident the change is grounded in). Dead links break that validation. The 2026-05-18 memory-phase-2 2c.5–2c.8 close-out hit this exactly — a plugin PR referenced a learning doc that only existed on a feature branch; a thin docs-only PR was opened so the URLs resolved.
+
+**Heuristic for when this applies**: if the plugin PR body contains a `https://github.com/.../blob/<default-branch>/docs/learnings/` URL, double-check that path resolves before submitting.
 
 #### 9.4: Document Solutions with /compound (If Applicable)
 

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
@@ -1,0 +1,252 @@
+---
+name: playbook:monitor-pr
+description: Monitor a PR's CI to green autonomously, iterating on failures with local-first fixes to minimize GitHub Actions minutes
+argument-hint: "[optional: PR number — auto-detected from current branch if omitted]"
+recommended-mode: auto-accept
+thinking-depth: normal
+---
+
+# Monitor PR Until CI Passes
+
+You are autonomously shepherding a pull request to all-green CI. **Cost discipline is the prime directive**: every push costs Actions minutes, so do as much validation locally as possible before triggering CI.
+
+## Your Goal
+
+Take a freshly opened (or just-pushed) PR and bring all CI checks to green — fixing failures along the way — while minimizing the number of remote runs.
+
+## Cost Discipline (Read This Before Doing Anything)
+
+The cost hierarchy of actions, cheapest first:
+
+1. **Free**: read local code, read recent commits, read CLAUDE.md / project docs for CI semantics
+2. **~Free** (API only, no Actions): `gh pr view`, `gh pr checks`, `gh run view --log-failed`
+3. **Local CPU only**: `npm run ci:local` (or project equivalent)
+4. **Free retrigger** (no new commit): `gh run rerun --failed <RUN_ID>`
+5. **Expensive** (~12 min minimum): pushing a commit that triggers full CI
+6. **Worst**: pushing a commit that fails CI again — wastes the run AND now the branch needs another fix
+
+Rules that fall out of this hierarchy:
+
+- **NEVER push without local validation passing first**. `npm run ci:local` (or project equivalent) must exit 0.
+- **NEVER push an empty commit to retrigger**. Use `gh run rerun --failed` — it's free and re-runs only the failed jobs.
+- **BATCH fixes** — if reading one failed log surfaces 3 root causes, fix all 3 in one commit, not three.
+- **Demote-and-re-promote** for test-only / docs-only / lint-only fixes: `gh pr ready <PR> --undo` first so the next push runs fast-CI only (~8 min instead of ~25 min). Re-promote when ready for the full pipeline.
+- **Read CLAUDE.md** for the project's specific CI semantics — draft-vs-ready behavior, path filters, `ci:full` labels, validation script names. They vary per repo and are load-bearing for cost decisions.
+
+## Available Tools
+
+- `/playbook:debug-ci` — invoke for systematic failure analysis when CI is red. Don't duplicate its logic; call into it.
+- `gh` CLI — `pr view`, `pr checks`, `run view --log-failed`, `pr ready [--undo]`, `run rerun --failed`
+- `ScheduleWakeup` (or the project's equivalent loop primitive) — for cache-friendly polling
+- Project's local validation: `npm run ci:local`, `test:verify`, etc.
+
+## Process
+
+### Step 0: Inputs and Setup
+
+1. **Determine the PR number**:
+   - From the `[PR number]` argument if provided
+   - Otherwise: `gh pr list --head $(git branch --show-current) --json number --jq '.[0].number'`
+   - If still no PR found: report to the user, stop. (Maybe they meant to push first.)
+
+2. **Verify `gh` is authed**: `gh auth status`
+
+3. **Read CLAUDE.md / project conventions** for:
+   - Local validation commands (`ci:local`, `test:verify`, etc.)
+   - Draft-vs-ready CI behavior (fast CI vs full CI)
+   - Path-filter rules (which heavy jobs are skipped under what conditions)
+   - `ci:full` label semantics (sticky vs one-shot)
+   - Forbidden patterns (e.g., "NEVER use `git push --no-verify`")
+
+   These are non-negotiable per-project rules — internalize them before acting.
+
+### Step 1: Snapshot Current State
+
+```bash
+gh pr view <N> --json statusCheckRollup,state,isDraft,mergeable,headRefOid
+gh run list --branch <BRANCH> --limit 5 --json databaseId,name,status,conclusion,createdAt,event
+```
+
+Classify each check into one of:
+
+| State | Action |
+|---|---|
+| `COMPLETED` + `SUCCESS` / `SKIPPED` / `NEUTRAL` | green — count it |
+| `IN_PROGRESS` / `QUEUED` | waiting — go to Step 2 |
+| `COMPLETED` + `FAILURE` / `CANCELLED` / `TIMED_OUT` | red — go to Step 3 |
+
+If **all green and nothing waiting**: jump to Step 4 (terminal).
+If **anything waiting and nothing red**: Step 2 (poll).
+If **anything red**: Step 3 (fix) — even if other things are still running, start preparing the fix.
+
+### Step 2: Poll at Cache-Friendly Intervals
+
+Anthropic prompt cache TTL is 5 minutes. Sleeping past 300s pays a cache miss on the next wake-up. Pick intervals at natural breakpoints:
+
+| Time remaining for the slowest in-progress job | Wakeup interval | Why |
+|---|---|---|
+| < 5 min | 270s | Stay in cache |
+| 5–60 min | 1200–1800s | One cache miss buys a long wait |
+| > 60 min | 3000–3600s | Worst-case cap |
+
+**Don't poll faster than the slowest currently-running job's typical duration.** That's pure waste. Typical durations:
+
+| Job type | Typical |
+|---|---|
+| Lint + typecheck + build | 2–4 min |
+| Unit tests (frontend + agent) | 3–6 min |
+| Integration tests | 5–10 min |
+| E2E tests (per shard) | 5–15 min |
+| Agent evals | 5–15 min |
+| Vercel/Railway preview build | 3–8 min |
+
+If you scheduled a 270s wakeup but the only in-progress job is Agent Evals (typically 10 min), you've burned cache for nothing. Pick the actual horizon.
+
+### Step 3: Triage and Fix Failures
+
+**Pull ALL failed logs first** before forming any hypothesis. Sharded `fail-fast: true` workflows often have multiple distinct failures masked by the first one:
+
+```bash
+# List all failed jobs across all recent runs on this branch
+gh run list --branch <BRANCH> --limit 5 --json databaseId,conclusion,name \
+  --jq '.[] | select(.conclusion == "failure") | "\(.databaseId) \(.name)"'
+
+# Pull each failed-job log to a file
+gh run view <RUN_ID> --log-failed > /tmp/failed-<RUN_ID>.log
+```
+
+Read each log end-to-end, not just the first error.
+
+#### 3a. Triage (delegate to `/playbook:debug-ci` Step 0)
+
+For each failure, classify:
+
+- **Is the failure related to this PR's changes?** `git diff --name-only origin/<base>...HEAD` — if the failing test/file isn't in the diff, it's likely flaky or pre-existing.
+- **Is it a known flaky test?** Search project docs for the test name; check recent CI history (`gh run list --status failure --limit 20`).
+- **Is it an environment/infra issue?** Rate limits, network blips, secret-rotation timing, etc.
+
+If the failure is **flaky** or **unrelated to this PR**: do NOT push a fix to this PR. Rerun with `gh run rerun --failed <RUN_ID>` (free) and surface the flake to the user for separate triage.
+
+#### 3b. Reproduce Locally
+
+- Run the SPECIFIC failing test locally with the same arguments CI used.
+- If it passes locally, look for env differences: Doppler/secrets, Node version, OS, FS case-sensitivity, time zone, locale.
+- If you can't reproduce locally AND it's a one-off failure on a normally-stable test: re-run with `gh run rerun --failed`, NOT a new commit.
+
+#### 3c. Fix Root Cause, Not Symptom
+
+Per CLAUDE.md "Structural Solutions Before Visual Patches": analyze the root cause before patching. A test timeout is rarely fixed by increasing the timeout; a flaky test is rarely fixed by adding a retry. Find the actual race / state leak / wrong assumption.
+
+#### 3d. Validate Locally (NON-NEGOTIABLE)
+
+Before pushing:
+
+```bash
+npm run ci:local    # or the project's equivalent — must exit 0
+```
+
+If the failure was specifically E2E or integration, also run that test class locally:
+
+```bash
+npm run test:e2e      # or the project's equivalent
+npm run test:integration
+```
+
+If `ci:local` is still red, you have not fixed the problem. Do not push.
+
+#### 3e. Push Minimal Commit
+
+- Stage only the fix files (not the whole working tree).
+- Use Conventional Commits (`fix:`, `chore:`, etc.).
+- One logical fix per commit when possible.
+- Push and return to Step 1.
+
+### Step 3.5: Demote-and-Re-Promote (Test-Only / Docs-Only Fixes)
+
+If your fix is **test-only, docs-only, or lint-only** AND the PR is currently non-draft, demote first:
+
+```bash
+gh pr ready <PR> --undo   # → next push runs fast-CI only (~8 min)
+git push
+# wait for fast-CI to pass via Step 2 polling
+gh pr ready <PR>          # → re-promote, fires full CI for final confidence check
+```
+
+This saves ~17 min per iteration. **Do NOT use this for behavioral code changes** — bypassing integration/E2E on real code is technical debt and the user has explicitly forbidden it in many projects (check CLAUDE.md).
+
+### Step 4: Terminal State — All Green
+
+When `gh pr view --json statusCheckRollup` shows 0 non-success/skip checks:
+
+1. **Confirm** `mergeable: MERGEABLE` and `state: OPEN`.
+2. **Check the user's original prompt** for "merge ready" or "ready to review" language. If present and `isDraft: true`, run `gh pr ready <PR>` and wait for the full-CI run that triggers.
+3. **Report back** with:
+   - PR URL
+   - Number of iteration commits added during monitoring (0 is the ideal)
+   - Estimated Actions minutes consumed (runs × typical durations)
+   - Whether `isDraft` is now false (relevant if user said "merge ready")
+   - Confirmation it's ready to merge (and if user pre-approved, run `gh pr merge --squash --delete-branch`)
+
+### Step 5: False-Green Sanity Check
+
+Before declaring victory, verify that **path-filtered heavy jobs actually ran on the same head commit** as the fast-CI passes. Per CLAUDE.md's documented learnings on path-filtered false-greens:
+
+- If only `frontend/**` changed → confirm Frontend E2E ran on this head SHA, not a previous one
+- If only `agent/**` changed → confirm Agent Evals + Agent Integration ran on this head SHA
+- If a "fix commit" only touched test files → confirm the heavy jobs ran AGAINST that commit, not the prior code commit (this is the documented false-green class)
+
+```bash
+gh run list --branch <BRANCH> --limit 10 --json headSha,name,conclusion \
+  --jq '.[] | "\(.headSha[0:8]) \(.conclusion) \(.name)"'
+```
+
+If a heavy job's `headSha` doesn't match the PR's `headRefOid`, that "green" is a false green — re-push or rerun against the current head.
+
+## Anti-Patterns (Don't Do These)
+
+| Anti-pattern | Why it's wrong |
+|---|---|
+| Polling every 60s when the longest in-progress job is ~10 min | Burns prompt cache and your context for no signal |
+| Pushing without `ci:local` passing | "Hope CI catches it" wastes a full run on a 5-second local check |
+| Empty-commit retrigger | `gh run rerun --failed` is free and re-runs only the failed jobs |
+| One commit per failure across multiple distinct failures | Read all logs first; fix together |
+| `git push --no-verify` | Bypasses the local quality gates that are there for a reason. CLAUDE.md typically forbids this; never use it without explicit user approval. |
+| Declaring victory on path-filtered greens | A fast-CI green on a no-code-change commit doesn't validate the actual code change. Confirm heavy jobs ran on the current head. |
+| Adding `ci:full` label and then a docs commit on top | Wastes a full-CI run on a docs change. Demote-and-re-promote instead. |
+
+## When to Escalate to the User
+
+- **3+ failed push iterations on the same root cause** — you have the wrong mental model; ask before continuing.
+- **A failure that introduces a new flaky test** — capture for project docs / `/playbook:learnings`, don't just rerun until it passes.
+- **Actions minutes consumed exceeds 2× the typical PR budget** (e.g., 5+ full-CI runs on a normal PR) — surface the cost so the user can choose to abandon.
+- **A failure that fundamentally changes the PR's scope or design** — get user input before reshaping the PR.
+
+## After Completion
+
+Suggest `/playbook:close` for session close-out. If any non-obvious failure modes surfaced (especially flaky or path-filter-related), suggest `/playbook:learnings` to capture them — these are the most expensive class of CI lessons because they repeat across PRs.
+
+---
+
+## Usage Pattern
+
+The most common invocation, right after `/playbook:work` or `/playbook:create-pr` completes:
+
+```
+/playbook:monitor-pr
+```
+
+(No arguments — auto-detects PR from current branch.)
+
+When monitoring a specific PR:
+
+```
+/playbook:monitor-pr 283
+```
+
+Combine with `/loop` for true autonomous operation across CI's long-tail timelines:
+
+```
+/loop /playbook:monitor-pr
+```
+
+This re-invokes the command at each `ScheduleWakeup` until the PR is green.


### PR DESCRIPTION
Promotes a repeated user prompt to a first-class workflow, plus two meta-retrospective fixes to the learnings skill.

## Why now

The user reports: *\"Every time a PR is submitted, I ask an agent to 'monitor the PR autonomously using the product playbook and iterate until all CI checks pass while minimizing github action minutes (aka do as much work locally as possible)'.\"* Three+ occurrences of the same prompt — time to codify.

Plus, the 2026-05-18 memory-phase-2 2c.5–2c.8 close-out surfaced two gaps in the learnings workflow's own execution:
1. The agent silently chose to skip CLAUDE.md additions (32k–40k band, sized over the soft limit but under the hard limit) instead of surfacing the trim/defer/skip choice to the user.
2. The plugin PR opened by the learnings flow referenced codebase learnings doc URLs that didn't yet resolve on the default branch — needed a thin docs-only PR first.

## What's in this PR

### `commands/workflows/monitor-pr.md` (new)
Full workflow for autonomous PR monitoring. Key features:

- **Cost hierarchy** as the prime directive: free reads → local CPU → free retriggers → expensive pushes. Each section ties decisions back to this.
- **Cache-aware polling intervals**: 270s when staying in 5-min prompt-cache TTL, 1200–1800s for longer waits. Includes typical-duration lookup table per job type so the agent doesn't poll faster than the slowest in-progress job.
- **Triage-first failure handling**: classify as PR-related / known-flaky / infra blip; only fix the first class with a commit. For the other two, use `gh run rerun --failed` (free, no new commit).
- **Demote-and-re-promote**: `gh pr ready <PR> --undo` for test-only / docs-only / lint-only fixes to run fast-CI only (~8 min vs ~25 min). Includes the explicit guardrail: NOT for behavioral changes.
- **False-green sanity check**: confirm path-filtered heavy jobs ran on the same head commit as the fast-CI passes. Codifies the documented false-green class from CLAUDE.md learnings.
- **Anti-patterns table** + **when-to-escalate** rules.
- Designed to be called as `/playbook:monitor-pr` (auto-detects PR from branch), or in a loop via `/loop /playbook:monitor-pr`.

### `commands/workflows/learnings.md` (two edits)
1. **Pre-Promotion check** now requires an explicit trim/defer-to-guides/skip recommendation when CLAUDE.md is in the 32k–40k band (between soft and hard limits). No more silent choices.
2. **Step 9.3** now requires checking that codebase learnings docs cited as evidence resolve on the default branch BEFORE opening the plugin PR — opens a thin docs-only PR first if needed.

### `CHANGELOG.md`
\`Unreleased\` section added with the three changes above.

## Usage

```
# After every PR submission
/playbook:monitor-pr

# For a specific PR
/playbook:monitor-pr 283

# Full autonomous loop until green
/loop /playbook:monitor-pr
```

The command will detect green / waiting / red state, poll at cache-friendly intervals when waiting, and on failure: pull all logs, triage, reproduce locally, fix root cause, validate with \`ci:local\`, and push minimally. It escalates to the user after 3+ failed iterations on the same root cause or 5+ full-CI runs consumed.

## Test plan

- [x] Command file is self-contained (no broken cross-references)
- [x] References existing commands correctly (\`/playbook:debug-ci\`, \`/playbook:close\`, \`/playbook:learnings\`)
- [x] Cost hierarchy is explicit and load-bearing for every decision in the workflow
- [x] Cache-friendly intervals match the documented Anthropic prompt-cache TTL behavior
- [x] False-green check references CLAUDE.md learnings (grounded in real incidents)
- [x] Meta-retro changes to learnings.md grounded in two documented sessions (recipes 2026-03-16 + memory-phase-2 2026-05-18)
- [ ] Validated by next \"monitor my PR\" invocation — should require zero per-step approvals

## Relationship to existing PRs

- **PR #44** (improve(work): Step 2.5 Existing-State Audit) — parallel concern. Both PRs come out of the 2026-05-18 close-out session but address different workflows. Can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)