### PR TITLE
feat(playbook): route portable workflows to /lore across the session-analysis cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **SpecStory Lore (`/lore`) routing across the session-analysis cluster** — `/playbook:improve-playbook`, `/playbook:identify-improvements`, `/playbook:learnings`, `/playbook:close`, and the `playbook-improvement-agent` now apply a shared decision boundary: gaps specific to *this* plugin → playbook track; knowledge to write down → docs; **portable, reusable-across-projects-and-harnesses workflows → `/lore`** (external [SpecStory Lore](https://github.com/specstoryai/getspecstory) skill, which forges such patterns into cross-harness `SKILL.md` packages from your own session history). `/playbook:close` gains an optional Phase 4.5 "Forge Flow" nudge. Lore is an optional external dependency — the playbook only *suggests* `/lore` and never auto-invokes it; all pointers are gated on Lore being installed. README "Forging Reusable Skills with Lore" section added.
 - **`/playbook:monitor-pr`** — New autonomous PR-monitoring workflow. Watches CI to green, fixes failures locally first, and minimizes GitHub Actions minutes via a cost hierarchy (local validation > free rerun > expensive push). Codifies cache-friendly polling intervals, demote-and-re-promote for test/docs-only fixes, false-green sanity checks for path-filtered jobs, and `gh run rerun --failed` over empty-commit retriggers. Designed to be invoked after every PR submission as `/playbook:monitor-pr` (auto-detects PR from branch) or in a loop via `/loop /playbook:monitor-pr`.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -234,6 +234,23 @@ This meta-workflow:
 
 The playbook learns from how you actually use it and grows to better support your workflows.
 
+### Forging Reusable Skills with Lore (optional)
+`/playbook:improve-playbook`, `/playbook:identify-improvements`, `/playbook:learnings`, and `/playbook:close` all mine your sessions, but they target *this* plugin and your codebase docs. When a pattern is instead a **portable, repeatable workflow you'd reuse across projects and harnesses**, those commands now point you to [**SpecStory Lore**](https://github.com/specstoryai/getspecstory) (`/lore`) — an external skill that forges such workflows into reusable, cross-harness `SKILL.md` packages grounded in your own session history.
+
+The decision boundary the playbook uses:
+
+| Signal | Route to |
+|--------|----------|
+| Gap specific to *this* plugin | `/playbook:improve-playbook` |
+| Knowledge to write down (codebase/docs) | `/playbook:learnings` |
+| Portable workflow reusable anywhere | `/lore` (SpecStory Lore) |
+
+Lore is an **optional external dependency** — the playbook only suggests `/lore` and never auto-invokes it. Install it globally with:
+
+```bash
+npx skills add specstoryai/getspecstory --skill lore --global
+```
+
 ## Project Structure
 
 ```

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/agents/workflow/playbook-improvement-agent.md
+++ b/plugins/product-playbook-for-agentic-coding/agents/workflow/playbook-improvement-agent.md
@@ -99,6 +99,8 @@ Compare each pattern against existing playbook capabilities:
 
 For each gap (❌) or partial coverage (⚠️), propose a solution:
 
+0. **Portable-workflow check (route to `/lore`)**: First decide whether the pattern is a *general-purpose, repeatable workflow* useful across projects and harnesses, rather than a gap specific to *this* playbook. If it is, recommend the user run **`/lore`** (SpecStory Lore, if installed) to forge it into a reusable, cross-harness skill from their own session history — do not propose a playbook-specific tool for it. Reserve the proposal types below for gaps in *this* plugin. Flag borderline patterns with both options so the user can choose.
+
 1. **Determine tool type**:
    - **Command**: User-invoked workflow with clear inputs/outputs
    - **Agent**: Autonomous multi-step task requiring judgment

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
@@ -104,6 +104,16 @@ You are facilitating an end-of-session close-out. Run each phase in order. Skip 
 3. If the user has input: invoke `/playbook:learnings` with `chat-session` trigger.
 4. If the user skips: proceed to Phase 5.
 
+## Phase 4.5: Forge Flow (optional)
+
+Skip silently if `--quick` was passed, or if the `lore` skill is not installed (check `~/.claude/skills/lore` / `Skill` tool availability), or if `.specstory/history/` has no sessions.
+
+Session close-out is a natural moment to turn accumulated work into reusable skills. If this session surfaced a *repeatable workflow you'd reuse across projects* (not a one-off), offer a lightweight nudge — do not run it for them:
+
+> "This session looks like it had a reusable workflow. Want to run `/lore` to forge it (and other patterns in your history) into a cross-harness skill? It mines this project's `.specstory/history`."
+
+`/lore` is interactive and user-driven — only point to it, never auto-invoke. If the user declines or there's nothing notable, skip silently.
+
 ## Phase 5: Summary
 
 Present a one-line status per phase:
@@ -115,6 +125,7 @@ Git: [Committed 3 files / Clean / 2 uncommitted (noted)]
 Tasks: [2 completed, 1 carried forward / No tasks document]
 Handoff: Saved to docs/checkpoints/latest.md
 Learnings: [Captured / Skipped]
+Skills: [Suggested /lore / Not applicable]
 ```
 
 ## Proactive Invocation
@@ -134,6 +145,7 @@ Each phase is independent and fails gracefully:
 - No tasks document? Skip Phase 2.
 - No active project? Write handoff inline instead of to file.
 - User declines learnings? Skip Phase 4.
+- `lore` skill not installed, or no `.specstory/history`? Skip Phase 4.5 silently.
 
 The command should always produce a useful summary, even if every phase is skipped (meaning: the session was clean with nothing to close out).
 
@@ -143,4 +155,5 @@ The command should always produce a useful summary, even if every phase is skipp
 |-----------|-------------|
 | `session-checkpoint` skill | Close-out writes to the same `docs/checkpoints/latest.md` format. The skill provides the format spec; this command orchestrates when and how it's written. |
 | `learnings` command | Close-out invokes learnings as its final phase. Learnings remains standalone for mid-session capture. |
+| `lore` skill (external, SpecStory) | Phase 4.5 points to `/lore` when a session surfaced a portable, reusable workflow. Close-out only suggests it; `/lore` is interactive and never auto-invoked. Learnings/improve-playbook handle plugin-specific gaps; `/lore` handles cross-harness skills. |
 | `autonomous-execution` skill | Already recommends checkpoints every 3 tasks. Close-out handles the end-of-session case. |

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/identify-improvements.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/identify-improvements.md
@@ -27,7 +27,7 @@ Before proceeding, inventory available tools:
 1. **Commands**: Other `/playbook:*` commands (learnings, improve-playbook)
 2. **Agents**: Specialized agents via Task tool (playbook-improvement-agent)
 3. **MCP Tools**: External service integrations via ToolSearch
-4. **Skills**: Domain expertise via Skill tool
+4. **Skills**: Domain expertise via Skill tool — including **`lore`** (SpecStory Lore) if installed, which forges portable, cross-harness skills from session history (see the routing note in Step 2).
 
 Select the most appropriate tools for the task at hand.
 
@@ -80,6 +80,8 @@ For each problem identified, brainstorm improvements:
 - **Context**: Missing project context or history
 - **Prompts**: Better prompt patterns
 - **Automation**: Manual steps that could be automated
+
+**Route to `/lore` when applicable**: If an improvement is really a *repeatable workflow you'd reuse across projects and harnesses* (e.g. "I keep doing this same multi-step thing by hand"), note that the user can run **`/lore`** (SpecStory Lore, if installed) to forge it into a reusable, cross-harness skill from their own session history — rather than tracking it here as a one-off improvement. Keep this list focused on improvements specific to *this* project/workflow.
 
 ### Step 3: Prioritize Top 10
 

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/improve-playbook.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/improve-playbook.md
@@ -29,7 +29,7 @@ Before proceeding, inventory available tools:
 1. **Commands**: Other `/playbook:*` commands (learnings, review-playbook)
 2. **Agents**: Specialized agents via Task tool (playbook-improvement-agent)
 3. **MCP Tools**: External service integrations via ToolSearch (GitHub)
-4. **Skills**: Domain expertise via Skill tool
+4. **Skills**: Domain expertise via Skill tool — including **`lore`** (SpecStory Lore) if installed, which forges portable, cross-harness skills from session history. See the "Portable-workflow check" in Step 4.
 
 Select the most appropriate tools for the task at hand.
 
@@ -169,6 +169,8 @@ Proceed to solution proposals?
 ---
 
 ### Step 4: Propose Solutions
+
+**Portable-workflow check (route to `/lore`)**: Before designing a playbook solution, ask whether the pattern is a *general-purpose, repeatable workflow* that would help across projects and harnesses — not a gap specific to *this* plugin. If so, recommend the user run **`/lore`** (SpecStory Lore, if installed) to forge it into a reusable, cross-harness skill grounded in their own session history, instead of adding a playbook-specific tool. Use the playbook track below only for gaps in *this* plugin. When a pattern is borderline, surface both options and let the user choose.
 
 **4.1 Design Solutions for Each Gap**
 

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -45,6 +45,8 @@ Both targets are active by default:
 1. **Codebase Documentation** — Patterns, gotchas, architecture decisions, debugging solutions. Location: `[current-codebase]/docs/`
 2. **Plugin Improvements** — Skill/workflow optimizations, missing steps, wrong defaults, new commands. Location: Plugin repository (`commands/`, `skills/`)
 
+> **Portable skills go to `/lore`, not the plugin.** When a learning is really a *repeatable workflow you'd reuse across projects and harnesses* (not specific to this codebase or this plugin), don't capture it as a doc or a new playbook command — recommend the user run **`/lore`** (SpecStory Lore, if installed) to forge it into a reusable, cross-harness skill grounded in their own session history. Target #2 is for improvements to *this* plugin; `/lore` is for general-purpose skills.
+
 ## Available Tools Discovery
 
 Before proceeding, consider what tools are available:


### PR DESCRIPTION
## What

Wires optional cross-references to the external **SpecStory Lore** skill (`/lore`) into every playbook touchpoint that already mines coding sessions, governed by a single decision boundary:

| Signal | Route to |
|--------|----------|
| Gap specific to *this* plugin | `/playbook:improve-playbook` |
| Knowledge to write down (codebase/docs) | `/playbook:learnings` |
| Portable workflow reusable anywhere | **`/lore`** (forge a cross-harness skill) |

## Why

The plugin already mines `.specstory/history` to improve itself and capture learnings, but nothing pointed users to forging **portable, cross-harness skills** from their own repeated workflows. `/lore` fills that gap. Leaning toward over-inclusion: an extra gated pointer costs one ignorable sentence; a missing one means the user never discovers `/lore` at the moment it's useful (asymmetric payoff).

## Touchpoints (8 files)

- `improve-playbook.md` — Tool Discovery + Step 4 "Portable-workflow check"
- `identify-improvements.md` — Tool Discovery + Step 2 routing note
- `learnings.md` — Output Targets callout (portable skills → `/lore`, not docs/plugin)
- `close.md` — optional **Phase 4.5 "Forge Flow"** nudge + summary/degradation/relationship entries
- `playbook-improvement-agent.md` — Phase 4 step 0 portable-workflow check (keeps agent consistent with the command that dispatches it)
- `plugin.json` — `0.20.0` → `0.21.0` (MINOR)
- `README.md` — new "Forging Reusable Skills with Lore" section + decision-boundary table
- `CHANGELOG.md` — `[Unreleased] → Added` entry

## Safety / no new dependency

Every `/lore` pointer is **gated on Lore being installed** and is **suggestion-only — never auto-invoked**. Users without Lore see zero behavior change; the plugin takes on no hard dependency.

## Testing

- **Structural:** frontmatter valid, `plugin.json` parses at 0.21.0, `close.md` phases coherent (1→2→3→4→4.5→5), zero auto-invoke language.
- **Behavioral dry-runs (5 scenarios):** portable→`/lore`, plugin-gap→playbook, gated-off→silent, installed→suggest-not-invoke, codebase-gotcha→docs. All passed.
- **Fully-live execution:** ran the *actual edited instructions* against real `.specstory/history` sessions with real tools. `/playbook:improve-playbook` routed a portable workflow → `/lore`, a `/playbook:tasks` gap → playbook track, and an auth gotcha → docs; `/playbook:close` Phase 4.5 gating + suggestion-only contract held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)