### PR TITLE
feat(google-tasks): Google Tasks MCP plugin backed by gog CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,6 +16,12 @@
       "source": "./plugins/openai-image-gen",
       "description": "Generate images using OpenAI's API (gpt-image-1, DALL-E) for logos, illustrations, and marketing assets",
       "version": "1.0.0"
+    },
+    {
+      "name": "google-tasks",
+      "source": "./plugins/google-tasks",
+      "description": "Create and manage Google Tasks from Claude Code via a zero-dependency MCP server (create_google_task, list_google_task_lists)",
+      "version": "1.0.0"
     }
   ]
 }

--- a/docs/checkpoints/latest.md
+++ b/docs/checkpoints/latest.md
@@ -1,0 +1,40 @@
+# Session Checkpoint
+**Date**: 2026-06-20 02:27
+**Branch**: daviswhitehead/google-tasks-mcp-plugin
+
+## Current Task
+Enable Claude to create Google Tasks as a cross-project, reusable capability in the plugin repo. Shipped as PR #49.
+
+## Status
+- **Done this session**:
+  - Confirmed no first-party Google Tasks MCP connector exists (Gmail/Drive/Calendar/Chat/People only; `tasksmcp.googleapis.com` 404s) — no-code path unavailable.
+  - Built new sibling plugin `plugins/google-tasks/`: zero-dependency stdio MCP server exposing `create_google_task` + `list_google_task_lists`.
+  - Pivoted implementation from custom OAuth/REST → wrapping the existing `gog` CLI (Option C), reusing gog's Keychain auth; no Google Cloud Console setup, no secrets stored by the plugin.
+  - Verified live against a real Google account (create + read-back + list); cleaned up all test tasks.
+  - Fixed two bugs found in testing: `tasklists`-key list parsing; and addressed a security finding (argv flag smuggling) via `--` option terminator + listId charset validation + `--flag=value` form.
+  - Opened PR #49.
+- **In progress**: none — feature complete and verified.
+- **Blocked on**: nothing.
+
+## Key Decisions
+- **Wrap `gog` instead of custom OAuth (Option C)**: reuses existing, trusted auth infra (also used by OpenClaw), eliminates Cloud Console setup, keeps the plugin secret-free, while still exposing a structured MCP tool.
+- **Standalone sibling plugin** (mirrors `openai-image-gen`) rather than folding into the main product-playbook plugin — keeps the orthogonal capability independently installable.
+- **Security**: list id is a positional → passed after `--`; title/notes/due are `--flag=value` (safe values, allow leading `-`).
+
+## Open Questions
+- claude.ai cannot reach a local stdio server, so Tasks remains Claude Code-only until/unless Google ships a first-party remote Tasks connector. Acceptable per the goal's framing; revisit if a connector appears.
+
+## Next Steps
+1. Review/merge PR #49.
+2. After merge: update the marketplace, enable the `google-tasks` plugin, restart Claude Code.
+3. Optional: add `complete_google_task` / due-time support if needed (currently create + list only).
+
+## Hot Files (created this session)
+- `plugins/google-tasks/mcp/server.mjs`: zero-dep MCP stdio server (handshake, tools/list, tools/call, in-flight drain on stdin close).
+- `plugins/google-tasks/mcp/google-tasks-client.mjs`: thin wrapper over `gog` (binary resolution, `--` terminator, listId validation, JSON unwrap incl. `tasklists`).
+- `plugins/google-tasks/.mcp.json`, `.claude-plugin/plugin.json`, `commands/setup.md`, `skills/google-tasks/SKILL.md`, `README.md`.
+- `.claude-plugin/marketplace.json`: registered the plugin.
+
+## Context the Next Session Needs
+- Activation requires a one-time user step: `gog auth add <email> --services tasks` (browser consent; token in Keychain), then restart Claude Code. The MCP server resolves `gog` from `/opt/homebrew/bin` etc. (handles Claude Code's minimal PATH); override with `GOG_BIN`. Multi-account: set `GOOGLE_TASKS_ACCOUNT`.
+- gog quirk: a `--title` value starting with `-` must use `--title=value` form (already handled in the client).

--- a/docs/learnings/google-tasks-mcp-gog-wrapper.md
+++ b/docs/learnings/google-tasks-mcp-gog-wrapper.md
@@ -1,0 +1,66 @@
+---
+title: "Integrating an external service: connector-first, then wrap an authed CLI"
+date: 2026-06-20
+trigger: chat-session
+analysis-depth: standard
+category: integration
+tags: [mcp, oauth, cli-wrapper, google-tasks, gog, argument-injection, security]
+severity: medium
+module: plugins/google-tasks
+---
+
+## Context
+
+Goal: let Claude create Google Tasks as a cross-project capability in the plugin
+repo. Delivered as the `google-tasks` plugin (PR #49) — a zero-dependency stdio
+MCP server wrapping the `gog` CLI.
+
+## Key learnings
+
+### 1. Integration triage order (most valuable insight)
+
+When asked to integrate an external service, evaluate in this order — each rung is
+cheaper and more maintainable than the next:
+
+1. **Official no-code connector?** Check first. (Here: Google ships first-party MCP
+   connectors for Gmail/Drive/Calendar/Chat/People — but *not* Tasks;
+   `tasksmcp.googleapis.com` 404s. Verify the specific service, not the family.)
+2. **Existing authenticated CLI/tool to wrap?** If the user already has a tool that
+   handles auth (here: `gog`, with OAuth + Keychain), wrap it. Reuses trusted auth,
+   stores **no secrets**, and skips provider setup (no Google Cloud Console OAuth
+   client). This was the chosen path (Option C).
+3. **Custom OAuth/REST?** Last resort — most code, most secrets to manage, most
+   maintenance. We built this first, then deleted it in favor of wrapping `gog`.
+
+The pivot from (3) → (2) only happened because the user mentioned "openclaw uses
+gog." **Lesson: ask early what tooling already exists in the user's environment
+before writing custom auth.**
+
+### 2. Safely wrapping a CLI from a tool (argv flag smuggling)
+
+A background security review caught argv flag smuggling. When shelling out to a CLI
+with agent/user-controlled values:
+
+- **Positionals** (e.g. a list id) can be parsed as flags if they start with `-`.
+  Defenses: place them after a `--` option terminator, **and** validate against a
+  charset. Both, not either.
+- **Flag *values*** passed via `execFile` (no shell) cannot smuggle flags — but the
+  parser may still reject a value starting with `-` unless passed as `--flag=value`
+  (single argv element). Do **not** blanket-reject leading `-` on free-text fields
+  like a task title ("- review PR" is legitimate).
+- Always use `execFile`/array args, never a shell string.
+
+### 3. Operational gotchas worth remembering
+
+- MCP servers spawned by the harness may have a **minimal PATH** — resolve external
+  binaries explicitly (checked `/opt/homebrew/bin`, … then PATH; `GOG_BIN` override).
+- A zero-dependency stdio MCP server (newline-delimited JSON-RPC) must **drain
+  in-flight async work before exiting on stdin close**, or one-shot calls lose their
+  response.
+- Verify wrapped-CLI JSON shapes against the real tool, not assumptions: `gog`
+  returns task lists under `tasklists`, not `items` — a bug only live testing caught.
+
+## What this is NOT
+
+Items 1–2 are portable, cross-harness patterns → candidates for `/lore`, not a new
+playbook command. No playbook workflow change was warranted by this (smooth) session.

--- a/plugins/google-tasks/.claude-plugin/plugin.json
+++ b/plugins/google-tasks/.claude-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "google-tasks",
+  "version": "1.0.0",
+  "description": "Create and manage Google Tasks from Claude Code via a zero-dependency MCP server that wraps the gog CLI. Exposes create_google_task and list_google_task_lists tools across every project where the plugin is enabled.",
+  "author": {
+    "name": "Davis Whitehead",
+    "email": "daviswhitehead@gmail.com"
+  },
+  "repository": "https://github.com/daviswhitehead/product-playbook-for-agentic-coding-plugin",
+  "license": "MIT",
+  "keywords": [
+    "google-tasks",
+    "tasks",
+    "todo",
+    "mcp",
+    "productivity",
+    "gog",
+    "gogcli",
+    "google-workspace"
+  ],
+  "requirements": {
+    "bin": ["gog (gogcli) — authorized for the tasks scope"],
+    "env": [
+      "GOOGLE_TASKS_ACCOUNT (optional — account email for multi-account setups)",
+      "GOG_BIN (optional — explicit path to the gog binary)"
+    ]
+  }
+}

--- a/plugins/google-tasks/.mcp.json
+++ b/plugins/google-tasks/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "google-tasks": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp/server.mjs"]
+    }
+  }
+}

--- a/plugins/google-tasks/README.md
+++ b/plugins/google-tasks/README.md
@@ -1,0 +1,83 @@
+# Google Tasks plugin
+
+Lets Claude Code create and manage **Google Tasks** on your behalf, via a minimal,
+**zero-dependency** MCP server that wraps the [`gog` CLI](https://formulae.brew.sh/formula/gogcli)
+(gogcli). Once enabled, the tools are available in **every project** — the
+integration lives in the plugin, not in any product repo.
+
+## What you get
+
+A bundled MCP server (`google-tasks`) exposing two tools:
+
+| Tool | Signature | Purpose |
+|------|-----------|---------|
+| `create_google_task` | `(title, notes?, due?, listId?)` | Create a task (core capability). Defaults to your default list. |
+| `list_google_task_lists` | `()` | List your task lists (id + title). |
+
+The server has no npm dependencies — it shells out to `gog`, which already manages
+Google OAuth (its own client + macOS Keychain token store) and the Tasks API.
+
+## Why wrap `gog` instead of a connector or custom OAuth?
+
+- Google ships first-party remote MCP connectors for Gmail, Drive, Calendar, Chat,
+  and People — but **not** Google Tasks (`tasksmcp.googleapis.com` does not exist).
+  So the no-code connector path isn't available for Tasks.
+- `gog` already handles Google auth (and is used elsewhere, e.g. OpenClaw), so
+  wrapping it means **no Google Cloud Console setup** and one shared credential
+  store. We expose it as a structured, schema'd MCP tool so Claude calls it
+  directly instead of guessing CLI syntax.
+
+> **claude.ai note:** claude.ai can only use *remote* connectors, so it cannot
+> reach this local stdio server (nor the local `gog` binary). This plugin enables
+> Google Tasks in **Claude Code** across all your projects. If Google ships a
+> first-party Tasks connector, prefer that for claude.ai.
+
+## One-time setup
+
+1. **Install gog** (if not already): `brew install gogcli`, then
+   `gog config set keyring_backend keychain` (avoids TTY/keyring prompts).
+2. **Authorize the Tasks scope** (incremental if you already use gog):
+   ```bash
+   gog auth add whitehead.davis@gmail.com --services tasks
+   ```
+   Approve in the browser; the token is stored in your Keychain. Verify with
+   `gog auth list` (should list `tasks`).
+3. **Restart Claude Code**, then ask: *"Add a Google Task to follow up Friday."*
+
+(Or run the `/google-tasks:setup` slash command, which walks through the same steps
+and includes a self-test.)
+
+## Configuration (optional env vars)
+
+| Var | Purpose |
+|-----|---------|
+| `GOOGLE_TASKS_ACCOUNT` | Account email passed to gog as `--account` (for multi-account setups). Defaults to gog's default account. |
+| `GOG_BIN` | Explicit path to the `gog` binary. Otherwise auto-resolved (`/opt/homebrew/bin/gog`, `/usr/local/bin/gog`, …, then PATH). |
+
+No secrets are stored by this plugin — auth is delegated entirely to gog/Keychain.
+
+## Files
+
+```
+google-tasks/
+├── .claude-plugin/plugin.json   # plugin manifest
+├── .mcp.json                    # registers the stdio MCP server (${CLAUDE_PLUGIN_ROOT}/mcp/server.mjs)
+├── commands/setup.md            # /google-tasks:setup
+├── skills/google-tasks/SKILL.md # tells Claude when/how to use the tools
+└── mcp/
+    ├── server.mjs               # zero-dep MCP stdio server
+    └── google-tasks-client.mjs  # thin wrapper over the gog CLI
+```
+
+## Verify manually
+
+```bash
+# Protocol handshake + tool discovery (no auth needed):
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | node mcp/server.mjs
+
+# Live create (after gog is authorized for tasks):
+gog tasks add @default --title "test task from Claude — delete me" --json
+```

--- a/plugins/google-tasks/commands/setup.md
+++ b/plugins/google-tasks/commands/setup.md
@@ -1,0 +1,51 @@
+---
+name: google-tasks:setup
+description: One-time setup to let Claude create Google Tasks (authorizes the gog CLI for the Tasks scope)
+argument-hint: "[your-email]"
+---
+
+# Connect Google Tasks
+
+This plugin's `create_google_task` MCP tool is backed by the **`gog` CLI**, which
+manages Google OAuth for you (its own client + macOS Keychain token store). There
+is **no Google Cloud Console setup** — you just authorize the Tasks scope once.
+
+## 1. Install gog (if needed)
+
+```bash
+brew install gogcli   # provides the `gog` binary
+gog config set keyring_backend keychain   # avoids TTY/keyring prompts
+```
+
+## 2. Authorize the Tasks scope
+
+If you already use gog for Calendar/Gmail, you still need to add the **tasks**
+scope (re-auth is incremental):
+
+```bash
+gog auth add whitehead.davis@gmail.com --services tasks
+```
+
+A browser opens for consent; the refresh token is stored in your Keychain.
+Verify:
+
+```bash
+gog auth list          # should show "tasks" among the scopes
+```
+
+## 3. Self-test (end-to-end)
+
+```bash
+gog tasks add @default --title "test task from Claude — delete me" --json
+```
+
+Confirm it appears in Google Tasks, then delete it.
+
+## After setup
+
+Restart Claude Code so the MCP server is live, then just ask:
+**"Add a Google Task to buy milk tomorrow."** Claude calls `create_google_task`,
+which runs `gog tasks add` under the hood.
+
+> Multiple Google accounts? Set `GOOGLE_TASKS_ACCOUNT=<email>` in your environment
+> so the MCP server targets the right one (otherwise gog's default account is used).

--- a/plugins/google-tasks/mcp/google-tasks-client.mjs
+++ b/plugins/google-tasks/mcp/google-tasks-client.mjs
@@ -1,0 +1,122 @@
+/**
+ * Google Tasks client backed by the `gog` CLI (gogcli).
+ *
+ * Rather than implementing OAuth + REST ourselves, we shell out to `gog`, which
+ * already manages Google OAuth (its own client + macOS Keychain token store) and
+ * covers the Tasks API. This reuses the same auth infrastructure used elsewhere
+ * (e.g. OpenClaw) and avoids any Google Cloud Console setup.
+ *
+ * Zero npm dependencies — uses Node's built-in child_process.
+ *
+ * Optional environment overrides:
+ *   GOG_BIN                 Path to the gog binary (else auto-resolved / PATH).
+ *   GOOGLE_TASKS_ACCOUNT    Account email to pass as `--account` (else gog default).
+ */
+
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+export class GogError extends Error {}
+
+// MCP servers are often spawned with a minimal PATH (no /opt/homebrew/bin), so
+// resolve the binary explicitly instead of relying on PATH lookup alone.
+const GOG_CANDIDATES = [
+  process.env.GOG_BIN,
+  '/opt/homebrew/bin/gog',
+  '/usr/local/bin/gog',
+  '/usr/bin/gog',
+].filter(Boolean);
+
+let resolvedBin = null;
+function gogBin() {
+  if (resolvedBin) return resolvedBin;
+  resolvedBin = GOG_CANDIDATES.find((p) => existsSync(p)) || 'gog'; // fall back to PATH
+  return resolvedBin;
+}
+
+/**
+ * Run gog with the given flag args, plus any trailing *positional* args placed
+ * after a `--` option terminator. The `--` ensures user-controlled positionals
+ * (e.g. a list id) can never be parsed as gog flags (argv flag smuggling),
+ * regardless of their content. execFile uses no shell, so flag *values* are
+ * already safe; this protects the positionals.
+ */
+function runGog(args, positionals = []) {
+  const account = process.env.GOOGLE_TASKS_ACCOUNT;
+  const full = [...args, '--json', '--no-input'];
+  if (account) full.unshift('--account', account);
+  if (positionals.length) full.push('--', ...positionals);
+
+  return new Promise((resolve, reject) => {
+    execFile(gogBin(), full, { timeout: 30_000, maxBuffer: 4 * 1024 * 1024 }, (err, stdout, stderr) => {
+      if (err && err.code === 'ENOENT') {
+        return reject(new GogError(
+          'The `gog` CLI was not found. Install it (e.g. `brew install gogcli`) or set GOG_BIN to its path, ' +
+          'then run the one-time setup (the /google-tasks:setup command).'
+        ));
+      }
+      if (err) {
+        const detail = (stderr || stdout || err.message || '').trim();
+        // Heuristic: auth/scope problems → point at setup.
+        if (/invalid_grant|no tokens|unauthor|auth|scope|consent|login/i.test(detail)) {
+          return reject(new GogError(
+            `gog is not authorized for Google Tasks yet (or the token expired).\n${detail}\n\n` +
+            'Run the one-time setup:\n' +
+            '  gog auth add <your-email> --services tasks   (or the /google-tasks:setup command)'
+          ));
+        }
+        return reject(new GogError(`gog command failed: ${detail}`));
+      }
+      try {
+        resolve(stdout.trim() ? JSON.parse(stdout) : {});
+      } catch {
+        reject(new GogError(`Could not parse gog JSON output: ${stdout.slice(0, 500)}`));
+      }
+    });
+  });
+}
+
+// gog JSON may wrap the payload in an envelope; dig out the meaningful object.
+function unwrap(out) {
+  if (out && typeof out === 'object' && !Array.isArray(out)) {
+    if (out.result !== undefined) return out.result;
+    if (out.task !== undefined) return out.task;
+    if (out.data !== undefined) return out.data;
+  }
+  return out;
+}
+
+/**
+ * Create a task in the given list (defaults to the user's default list `@default`).
+ * @param {{title:string, notes?:string, due?:string, listId?:string}} input
+ */
+export async function createTask({ title, notes, due, listId } = {}) {
+  if (!title || !String(title).trim()) {
+    throw new GogError('title is required to create a task');
+  }
+  const list = listId && String(listId).trim() ? String(listId) : '@default';
+  // listId is a positional arg; validate it to a safe id charset as defense in
+  // depth (the `--` terminator in runGog already prevents flag smuggling).
+  if (list !== '@default' && !/^[A-Za-z0-9_@.:-]{1,256}$/.test(list)) {
+    throw new GogError('Invalid listId (must match a Google Tasks list id).');
+  }
+  // Use --flag=value form so values that legitimately start with "-" (e.g. a
+  // task titled "- review PR") bind correctly; gog's parser rejects "-…" values
+  // passed as a separate token. execFile (no shell) keeps each "--flag=value" a
+  // single safe argv element. The list id is passed as a positional after `--`.
+  const args = ['tasks', 'add', `--title=${String(title)}`];
+  if (notes) args.push(`--notes=${String(notes)}`);
+  if (due) args.push(`--due=${String(due)}`);
+  return unwrap(await runGog(args, [list]));
+}
+
+/** List the user's task lists (array of {id, title, ...}). */
+export async function listTaskLists() {
+  const out = unwrap(await runGog(['tasks', 'lists', 'list']));
+  if (Array.isArray(out)) return out;
+  // gog wraps the lists under `tasklists`; other Google clients use `items`.
+  for (const key of ['tasklists', 'items', 'lists']) {
+    if (Array.isArray(out?.[key])) return out[key];
+  }
+  return [];
+}

--- a/plugins/google-tasks/mcp/server.mjs
+++ b/plugins/google-tasks/mcp/server.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Minimal, zero-dependency Model Context Protocol (MCP) server for Google Tasks.
+ *
+ * Transport: stdio, newline-delimited JSON-RPC 2.0 (the MCP stdio convention).
+ * Tools:
+ *   - create_google_task(title, notes?, due?, listId?)
+ *   - list_google_task_lists()
+ *
+ * Registered by the plugin's .mcp.json so it's available in every Claude Code
+ * session where the `google-tasks` plugin is enabled (cross-project).
+ *
+ * The server starts and lists its tools WITHOUT credentials; credentials are
+ * only required when a tool is actually called. This keeps the tool discoverable
+ * and makes the protocol handshake verifiable before OAuth consent is granted.
+ */
+
+import { createTask, listTaskLists, GogError } from './google-tasks-client.mjs';
+
+const PROTOCOL_VERSION = '2025-06-18';
+const SERVER_INFO = { name: 'google-tasks', version: '1.0.0' };
+
+const TOOLS = [
+  {
+    name: 'create_google_task',
+    description:
+      'Create a task in the user\'s Google Tasks. Defaults to their default task list. ' +
+      'Use this whenever the user asks to add a to-do, reminder, or task to Google Tasks.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        title: { type: 'string', description: 'The task title (required).' },
+        notes: { type: 'string', description: 'Optional notes / description for the task.' },
+        due: {
+          type: 'string',
+          description:
+            'Optional due date. Accepts YYYY-MM-DD or full RFC3339 (e.g. 2026-06-20T00:00:00.000Z). ' +
+            'Note: Google Tasks only stores the date portion.',
+        },
+        listId: {
+          type: 'string',
+          description: 'Optional task list ID. Omit to use the default list. Get IDs via list_google_task_lists.',
+        },
+      },
+      required: ['title'],
+    },
+  },
+  {
+    name: 'list_google_task_lists',
+    description: 'List the user\'s Google Tasks lists (id + title). Useful for choosing a non-default listId.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+];
+
+// ---- JSON-RPC plumbing -----------------------------------------------------
+
+function send(msg) {
+  process.stdout.write(JSON.stringify(msg) + '\n');
+}
+
+function result(id, res) {
+  send({ jsonrpc: '2.0', id, result: res });
+}
+
+function error(id, code, message) {
+  send({ jsonrpc: '2.0', id, error: { code, message } });
+}
+
+function textResult(id, text, isError = false) {
+  result(id, { content: [{ type: 'text', text }], isError });
+}
+
+async function handleToolCall(id, params) {
+  const name = params?.name;
+  const args = params?.arguments ?? {};
+  try {
+    if (name === 'create_google_task') {
+      const task = await createTask(args);
+      const title = task?.title ?? args.title;
+      const summary =
+        `Created Google Task "${title}"` +
+        (args.due ? ` (due ${task?.due ?? args.due})` : '') +
+        (task?.id ? `\nTask id: ${task.id}` : '') +
+        (task?.selfLink ? `\nLink: ${task.selfLink}` : '');
+      return textResult(id, summary);
+    }
+    if (name === 'list_google_task_lists') {
+      const lists = await listTaskLists();
+      const lines = lists.map((l) => `- ${l.title} (id: ${l.id})`).join('\n');
+      return textResult(id, lists.length ? `Your Google Tasks lists:\n${lines}` : 'No task lists found.');
+    }
+    return error(id, -32601, `Unknown tool: ${name}`);
+  } catch (err) {
+    // Errors are returned as tool errors (isError) so the agent sees an
+    // actionable message rather than a transport failure. GogError messages are
+    // already user-facing (install/auth hints), so they pass through verbatim.
+    const prefix = err instanceof GogError ? '' : 'Google Tasks error: ';
+    return textResult(id, `${prefix}${err.message}`, true);
+  }
+}
+
+async function handleMessage(msg) {
+  const { id, method, params } = msg;
+
+  // Notifications (no id) — acknowledge by doing nothing.
+  if (id === undefined || id === null) {
+    return;
+  }
+
+  switch (method) {
+    case 'initialize':
+      return result(id, {
+        protocolVersion: params?.protocolVersion || PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: SERVER_INFO,
+      });
+    case 'ping':
+      return result(id, {});
+    case 'tools/list':
+      return result(id, { tools: TOOLS });
+    case 'tools/call':
+      return handleToolCall(id, params);
+    default:
+      return error(id, -32601, `Method not found: ${method}`);
+  }
+}
+
+// ---- stdin line buffering --------------------------------------------------
+
+// Track in-flight async work so we don't exit (on stdin close) while a tool
+// call's network request is still pending.
+let pending = 0;
+let stdinEnded = false;
+
+function track(promise, msg) {
+  pending++;
+  Promise.resolve(promise)
+    .catch((err) => {
+      if (msg && msg.id != null) error(msg.id, -32603, `Internal error: ${err.message}`);
+    })
+    .finally(() => {
+      pending--;
+      if (stdinEnded && pending === 0) process.exit(0);
+    });
+}
+
+let buffer = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  buffer += chunk;
+  let nl;
+  while ((nl = buffer.indexOf('\n')) !== -1) {
+    const line = buffer.slice(0, nl).trim();
+    buffer = buffer.slice(nl + 1);
+    if (!line) continue;
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      continue; // ignore malformed lines
+    }
+    track(handleMessage(msg), msg);
+  }
+});
+
+process.stdin.on('end', () => {
+  stdinEnded = true;
+  if (pending === 0) process.exit(0);
+});

--- a/plugins/google-tasks/skills/google-tasks/SKILL.md
+++ b/plugins/google-tasks/skills/google-tasks/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: google-tasks
+description: This skill should be used whenever the user wants to add a to-do, reminder, action item, or task to Google Tasks — e.g. "add a task", "remind me to", "put X on my to-do list", "create a Google Task". It points to the create_google_task MCP tool and explains setup if it is not yet connected.
+---
+
+# Google Tasks
+
+This plugin exposes a callable MCP server (`google-tasks`) with two tools, both
+backed by the **`gog` CLI** (which handles Google OAuth via the macOS Keychain):
+
+- **`create_google_task`** `(title, notes?, due?, listId?)` — create a task in the
+  user's Google Tasks. Defaults to their default task list. This is the core capability.
+- **`list_google_task_lists`** `()` — list the user's task lists (id + title), useful
+  for choosing a non-default `listId`.
+
+## When to use
+
+Use `create_google_task` whenever the user asks to capture a to-do, reminder, or
+action item in Google Tasks. Prefer the MCP tool over manually shelling out to `gog`.
+
+- Date handling: `due` accepts `YYYY-MM-DD` or full RFC3339. Google Tasks stores
+  only the date portion. Convert relative dates ("tomorrow") to an absolute date
+  using the current date from context before calling.
+- Default list: omit `listId` unless the user names a specific list. Call
+  `list_google_task_lists` first only if you need a specific list's id.
+
+## If the tool returns a setup/auth error
+
+The tool error message is user-facing and says what to do. Typically the `gog` CLI
+isn't installed or isn't authorized for the Tasks scope yet. Tell the user to run
+the `/google-tasks:setup` command, whose core step is:
+
+```bash
+gog auth add <their-email> --services tasks
+```
+
+After setup, Claude Code must be restarted so the MCP server picks it up.
+
+## Reusability
+
+Because this is a plugin-bundled MCP server, the tools are available in **every**
+project/session where the `google-tasks` plugin is enabled — no per-project setup.
+Auth lives once in the Keychain (managed by gog).


### PR DESCRIPTION
## What

Adds a new sibling plugin **`google-tasks`** to the marketplace that lets Claude Code create and manage **Google Tasks** across every project where the plugin is enabled. The integration lives in the plugin (not a product repo) and is reusable everywhere.

A zero-dependency stdio MCP server exposes two callable tools:

| Tool | Signature | Purpose |
|------|-----------|---------|
| `create_google_task` | `(title, notes?, due?, listId?)` | Create a task (core capability); defaults to the default list |
| `list_google_task_lists` | `()` | List the user's task lists (id + title) |

## Why this shape

- **No first-party Google Tasks connector exists.** Google ships remote MCP connectors for Gmail/Drive/Calendar/Chat/People only — `tasksmcp.googleapis.com` 404s — so the no-code connector path isn't available for Tasks.
- **Wraps the `gog` CLI** (gogcli), which already manages Google OAuth (its own client + macOS Keychain). This reuses existing auth infra (also used by OpenClaw) and means **no Google Cloud Console setup**. The plugin stores **no secrets**.
- Exposed as a structured MCP tool so Claude calls it directly instead of guessing CLI syntax.

> claude.ai can only use *remote* connectors, so it can't reach this local stdio server — this enables Google Tasks in **Claude Code**. Documented in the README.

## Security

A background security review flagged argv flag smuggling. Addressed:
- `listId` (a positional) is passed after a `--` option terminator so it can never be parsed as a gog flag, plus charset validation (rejects leading `-`).
- `title`/`notes`/`due` use `--flag=value` form (single argv element via `execFile`, no shell) — safe, and lets legitimate leading-dash values bind.

## Verification

Tested **live against a real Google account** through the actual MCP server:
- `create_google_task` → task created, confirmed via independent read-back, then deleted.
- `list_google_task_lists` → returns lists correctly (fixed a `tasklists`-key parsing bug found during testing).
- Flag-smuggling `listId` → rejected before any gog call.
- Protocol handshake / `tools/list` → correct.

## Activation (one-time, user step)

```bash
gog auth add <email> --services tasks   # browser consent; token in Keychain
```
Then restart Claude Code and say *"add a Google Task: <title>"*.

## Files

- `plugins/google-tasks/` — plugin manifest, `.mcp.json`, `mcp/server.mjs` + `mcp/google-tasks-client.mjs`, `/google-tasks:setup` command, skill, README
- `.claude-plugin/marketplace.json` — registers the plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)