### PR TITLE
fix(release): sync to 0.22.0 + guard against unbumped plugin changes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.17.0"
+      "version": "0.22.0"
     },
     {
       "name": "openai-image-gen",

--- a/.github/workflows/plugin-guard.yml
+++ b/.github/workflows/plugin-guard.yml
@@ -1,0 +1,36 @@
+name: Plugin Guard
+
+# Enforces the invariants that keep plugin updates actually reaching users:
+#   1. Structure/consistency: every marketplace.json entry version matches its
+#      plugin.json version (validate-plugin.sh).
+#   2. Propagation: any change to a plugin's files is accompanied by a version
+#      bump (check-version-bump.sh) — because auto-update is version-keyed and an
+#      unbumped change silently never propagates.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so we can diff against the base branch
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Validate plugin structure + version consistency
+        run: bash scripts/validate-plugin.sh
+
+      - name: Enforce version bump on plugin changes
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: bash scripts/check-version-bump.sh "origin/${BASE_REF}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-06-19
+
+### Fixed
+- **Plugin version drift across manifests** — `marketplace.json` had fallen 4 versions behind `plugin.json` (0.17.0 vs 0.21.0). Synced all manifests to a single version and backfilled the missing 0.20.0/0.21.0 CHANGELOG sections. The previously-shipped-but-undelivered "Out-of-Repo Changes" checkpoint work (committed at 0.21.0 without a version bump, so auto-update never re-pulled it) now ships under this release.
+
+### Added
+- **Release-propagation guardrails** — New `scripts/check-version-bump.sh` fails CI when any plugin's files change without a `plugin.json` version bump (the root cause of stale installs: auto-update is version-keyed, so content changes at an unchanged version silently never reach users). `scripts/validate-plugin.sh` now also asserts every `marketplace.json` entry's `version` matches the plugin's own `plugin.json` version. Both run on every PR to `main` via the new `.github/workflows/plugin-guard.yml`.
+- **`scripts/sync-version.sh <version>`** — One command bumps `plugin.json` and the `marketplace.json` entry together so the two can never drift apart, and reminds you to update the CHANGELOG.
+
+### Changed
+- **CLAUDE.md / README — propagation model documented** — Versioning Requirements now explains that a version bump is the update trigger and a content change without a bump never propagates; the Quality Checklist references the new guard scripts. README "Updating the Plugin" documents the verified refresh path.
+
+### Why
+Driven by a sync session (2026-06-19): a content-only commit (`914709f`, the out-of-repo checkpoint feature) shipped at the same 0.21.0 version, so every local install silently stayed stale despite `autoUpdate: true`. Root cause: auto-update keys off the version number, and nothing enforced "content changed ⇒ version bumped." These guardrails make that failure mode impossible to merge.
+
+## [0.21.0] - 2026-06-18
+
 ### Added
 - **SpecStory Lore (`/lore`) routing across the session-analysis cluster** — `/playbook:improve-playbook`, `/playbook:identify-improvements`, `/playbook:learnings`, `/playbook:close`, and the `playbook-improvement-agent` now apply a shared decision boundary: gaps specific to *this* plugin → playbook track; knowledge to write down → docs; **portable, reusable-across-projects-and-harnesses workflows → `/lore`** (external [SpecStory Lore](https://github.com/specstoryai/getspecstory) skill, which forges such patterns into cross-harness `SKILL.md` packages from your own session history). `/playbook:close` gains an optional Phase 4.5 "Forge Flow" nudge. Lore is an optional external dependency — the playbook only *suggests* `/lore` and never auto-invokes it; all pointers are gated on Lore being installed. README "Forging Reusable Skills with Lore" section added.
 - **`/playbook:monitor-pr`** — New autonomous PR-monitoring workflow. Watches CI to green, fixes failures locally first, and minimizes GitHub Actions minutes via a cost hierarchy (local validation > free rerun > expensive push). Codifies cache-friendly polling intervals, demote-and-re-promote for test/docs-only fixes, false-green sanity checks for path-filtered jobs, and `gh run rerun --failed` over empty-commit retriggers. Designed to be invoked after every PR submission as `/playbook:monitor-pr` (auto-detects PR from branch) or in a loop via `/loop /playbook:monitor-pr`.
@@ -30,6 +47,19 @@ Captured during the 2026-05-18 memory-phase-2 2c.5–2c.8 close-out session (che
 **2026-06-18 OpenClaw runtime-outage session** — The checkpoint "Out-of-Repo Changes" element came from a long ops/debugging session that fixed a Mini Me / OpenClaw Codex outage. ~90% of the consequential changes were outside the repo (a `@openai/codex` upgrade, an OpenClaw `2026.2.3 → 2026.6.1` migration, OAuth re-auth, runtime config edits). The repo-only checkpoint format had no home for any of it — exactly the "would take time to re-discover" context the skill exists to preserve — so the handoff had to be hand-adapted. Promoted that adaptation into the format.
 
 **2026-06-08 acquisition-engine deep retrospective** — The `autonomous-execution`, `user-journey-testing`, `session-checkpoint`, `close`, and `learnings` Pre-Check A changes came from a deep retrospective on chef-chopsky's 10-week acquisition project. Two root causes drove every finding: **comfort with proxies for real validation** — static checks substituting for runtime truth (T11 `recipe_cta_clicked` shipped zero events for 12 days after being marked done on "imports are clean"; the zero-event symptom was visible 6 weeks before root-cause and rationalized away as "no traffic") — and **building substituting for the scary manual work** (10 weeks of measurement infra, exactly one acquisition channel actually run). The foundation-consistency check and the recency-before-drift rule came from the meta-retrospective on this same session.
+
+## [0.20.0] - 2026-04-22
+
+### Added
+- **`conciseness-check` skill** — Cross-pollinated from the ai-native-product-playbook, plus AGENTS.md principles 6 (Concise by Default) and 7 (Critique Before Checkpoint).
+- **Methods Library (`resources/methods/`)** — 4 standalone thinking frameworks: Socratic Questioning, Strategy Kernel, Impact Estimation, Devil's Advocate.
+- **`/playbook:close`** — Session close-out command with a 5-phase workflow (git check → task cleanup → handoff context → learnings → summary).
+
+### Changed
+- **Architectural patterns across the plugin** — `recommended-mode` and `thinking-depth` frontmatter added to all 36 commands, proactive invocation on 4 skills, completeness gates on `learnings` and `critique`, and method references in 4 commands. 48 files changed.
+
+### Why
+Cross-pollinated four workstreams (conciseness & AI-filler, methods library, session close-out, architectural patterns) from the ai-native-product-playbook into this plugin.
 
 ## [0.19.0] - 2026-04-26
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,54 @@
 # Product Playbook Plugin Development
 
-## Versioning Requirements
+## Versioning & Propagation (read this first)
 
-**IMPORTANT**: Every change to this plugin MUST include updates to:
+**The propagation model — why the version bump is not optional:**
+Claude Code's marketplace auto-update is **version-keyed**. A user's install only
+re-pulls a plugin when its **version number changes**. This means:
 
-1. **`.claude-plugin/plugin.json`** - Bump version using semver
-2. **`README.md`** - Verify/update component counts and tables
+> **A content change shipped at an unchanged version silently NEVER reaches users —
+> even with `autoUpdate: true`.** The install stays stale until the version bumps.
+
+This bit us once already: a content-only commit shipped at the same version, and
+every local install silently stayed on the old copy. The guardrails below make that
+mistake impossible to merge.
+
+**IMPORTANT**: Every change to a plugin MUST bump its version in **both** files, which
+must always match:
+
+1. **`plugins/<plugin-name>/.claude-plugin/plugin.json`** — the plugin's own version
+2. **`.claude-plugin/marketplace.json`** — the marketplace entry's `version`
+
+Do the bump with the helper (it edits both together so they can't drift):
+
+```bash
+scripts/sync-version.sh <new-version>          # e.g. 0.22.0
+# then add a "## [<new-version>] - YYYY-MM-DD" section to CHANGELOG.md
+```
+
+Also update **`README.md`** if component counts/tables changed.
 
 ### Version Bumping Rules
 
 - **MAJOR** (1.0.0 → 2.0.0): Breaking changes, major reorganization
 - **MINOR** (1.0.0 → 1.1.0): New commands, agents, or skills
 - **PATCH** (1.0.0 → 1.0.1): Bug fixes, doc updates, minor improvements
+
+### Enforcement
+
+Two guards run on every PR to `main` (`.github/workflows/plugin-guard.yml`), and you
+can run them locally:
+
+- `scripts/validate-plugin.sh` — asserts each `marketplace.json` entry's version
+  matches the corresponding `plugin.json` version.
+- `scripts/check-version-bump.sh [base-ref]` — fails if any plugin's files changed
+  versus the base branch without a `plugin.json` version bump.
+
+### Delivering an update to installed machines
+
+Because this is a marketplace-embedded plugin (plugin source is a relative path
+inside the marketplace repo), a pushed-to-`main` version bump is the trigger, but a
+machine may need a marketplace refresh to pull it. See README → "Updating the Plugin".
 
 ## Directory Structure
 
@@ -172,7 +209,10 @@ Two output targets:
 
 Before committing changes:
 
-- [ ] Version bumped in plugin.json
+- [ ] Version bumped in **both** `plugin.json` and `marketplace.json` (use `scripts/sync-version.sh`)
+- [ ] `CHANGELOG.md` has a section for the new version
+- [ ] `scripts/validate-plugin.sh` passes (incl. version consistency)
+- [ ] `scripts/check-version-bump.sh` passes (plugin changed ⇒ version bumped)
 - [ ] README.md updated if components changed
 - [ ] All commands have proper frontmatter (name, description)
 - [ ] All agents have proper frontmatter (name, description, model)

--- a/README.md
+++ b/README.md
@@ -56,22 +56,34 @@ Not every project needs every step. A small feature might start at PRD. A new pr
 
 ### Updating the Plugin
 
-This plugin uses a marketplace-embedded structure (plugin source is inside the marketplace repo). The "Update now" button in the plugin UI won't work directly—this is expected behavior for this type of plugin architecture.
+Updates are **version-keyed**: a Claude Code install only picks up a new copy when the
+plugin's **version number changes**. A change published at the *same* version will not
+propagate — installs stay on the old copy even with `autoUpdate` enabled. (Maintainers:
+every change bumps the version; this is enforced in CI — see `CLAUDE.md` → "Versioning &
+Propagation".)
 
-**To update to the latest version:**
+This plugin also uses a marketplace-embedded structure (plugin source is a relative path
+inside the marketplace repo), so a machine may need a marketplace refresh to pull a new
+version, and the "Update now" button on the *plugin* won't work directly.
 
-1. **Update the marketplace** (pulls latest from GitHub):
+**To pull the latest version onto a machine:**
+
+1. **Refresh the marketplace** (pulls latest from GitHub):
    ```
    /plugin → Marketplaces tab → select "product-playbook-marketplace" → Update now
    ```
 
-2. **Reinstall the plugin**:
+2. **Reinstall the plugin** if it didn't refresh to the new version automatically:
    ```
    /plugin → Installed tab → select the plugin → Uninstall
    /plugin → Marketplaces tab → select marketplace → Install
    ```
 
-**Note:** The "Local plugins cannot be updated remotely" message appears because the plugin uses a relative path source within the marketplace. This is the same pattern used by many plugins in Anthropic's official marketplace.
+You can confirm the live version under `/plugin → Installed`.
+
+**Note:** The "Local plugins cannot be updated remotely" message appears because the
+plugin uses a relative path source within the marketplace. This is the same pattern used
+by many plugins in Anthropic's official marketplace.
 
 ## Commands
 

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/scripts/check-version-bump.sh
+++ b/scripts/check-version-bump.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# check-version-bump.sh — Fail if a plugin's files changed without a version bump.
+#
+# WHY THIS EXISTS:
+#   Claude Code marketplace auto-update is *version-keyed*: a plugin only re-installs
+#   on users' machines when its version number changes. So a content change shipped
+#   at an unchanged version silently never propagates — installs stay stale forever.
+#   This check makes that mistake impossible to merge: if any tracked file under a
+#   plugin directory differs from the base branch, that plugin's plugin.json version
+#   MUST also differ.
+#
+# USAGE:
+#   scripts/check-version-bump.sh [base-ref]
+#     base-ref   git ref to diff against (default: origin/main)
+#
+# Exit 0 = all changed plugins bumped their version (or nothing changed).
+# Exit 1 = a plugin changed but its version did not bump.
+
+set -uo pipefail
+
+BASE_REF="${1:-origin/main}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+FAILURES=0
+
+# Resolve the base ref; if it isn't present (shallow CI clone), try to fetch it.
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+    git fetch --quiet origin "${BASE_REF#origin/}" 2>/dev/null || true
+fi
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+    echo -e "${YELLOW}WARNING: base ref '$BASE_REF' not found — skipping version-bump check.${NC}"
+    exit 0
+fi
+
+MERGE_BASE="$(git merge-base "$BASE_REF" HEAD 2>/dev/null || echo "$BASE_REF")"
+
+version_of() {  # version_of <git-ref-or-WORKING> <path>
+    local ref="$1" path="$2" content
+    if [ "$ref" = "WORKING" ]; then
+        [ -f "$path" ] || return 1
+        content="$(cat "$path")"
+    else
+        content="$(git show "$ref:$path" 2>/dev/null)" || return 1
+    fi
+    printf '%s' "$content" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version",""))' 2>/dev/null
+}
+
+echo "Checking version bumps against $BASE_REF (merge-base ${MERGE_BASE:0:8})..."
+echo "-------------------------------------------"
+
+shopt -s nullglob
+for plugin_json in plugins/*/.claude-plugin/plugin.json; do
+    plugin_dir="$(dirname "$(dirname "$plugin_json")")"   # plugins/<name>
+    name="$(basename "$plugin_dir")"
+
+    # Did anything under this plugin change vs the merge-base?
+    if git diff --quiet "$MERGE_BASE" -- "$plugin_dir"; then
+        echo -e "${GREEN}OK: $name unchanged${NC}"
+        continue
+    fi
+
+    cur_version="$(version_of WORKING "$plugin_json" || true)"
+    base_version="$(version_of "$MERGE_BASE" "$plugin_json" || echo "")"
+
+    if [ -z "$base_version" ]; then
+        echo -e "${GREEN}OK: $name is new (version $cur_version)${NC}"
+        continue
+    fi
+
+    if [ "$cur_version" = "$base_version" ]; then
+        echo -e "${RED}FAIL: $name changed but version not bumped (still $cur_version)${NC}"
+        echo -e "       Run: scripts/sync-version.sh <new-version> $name"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo -e "${GREEN}OK: $name bumped $base_version -> $cur_version${NC}"
+    fi
+done
+
+echo ""
+if [ "$FAILURES" -gt 0 ]; then
+    echo -e "${RED}Version-bump check FAILED ($FAILURES plugin(s) changed without a bump).${NC}"
+    echo "Auto-update is version-keyed: unbumped changes never reach users' installs."
+    exit 1
+fi
+echo -e "${GREEN}Version-bump check PASSED.${NC}"
+exit 0

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# sync-version.sh — Bump a plugin's version everywhere it must match, in one step.
+#
+# WHY THIS EXISTS:
+#   Plugin updates are *version-keyed*. Claude Code's marketplace auto-update only
+#   re-pulls a plugin when its version number changes. A content change shipped at
+#   an unchanged version silently NEVER reaches users' installs — even with
+#   autoUpdate enabled. And the version lives in TWO files that must agree:
+#     - plugins/<name>/.claude-plugin/plugin.json   (the plugin's own version)
+#     - .claude-plugin/marketplace.json             (the marketplace entry version)
+#   If they drift, installs and the marketplace listing disagree. This script
+#   updates both together so they can't.
+#
+# USAGE:
+#   scripts/sync-version.sh <new-version> [plugin-name]
+#
+#   <new-version>   e.g. 0.22.0  (semver: MAJOR.MINOR.PATCH)
+#   [plugin-name]   defaults to "product-playbook-for-agentic-coding"
+#
+# AFTER RUNNING:
+#   1. Add a "## [<new-version>] - YYYY-MM-DD" section to CHANGELOG.md
+#   2. Run scripts/validate-plugin.sh (consistency is enforced there + in CI)
+#   3. Commit, push, and merge to main — the bump is what triggers propagation.
+
+set -euo pipefail
+
+NEW_VERSION="${1:-}"
+PLUGIN_NAME="${2:-product-playbook-for-agentic-coding}"
+
+if [ -z "$NEW_VERSION" ]; then
+    echo "ERROR: missing <new-version>"
+    echo "Usage: scripts/sync-version.sh <new-version> [plugin-name]"
+    exit 1
+fi
+
+if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "ERROR: '$NEW_VERSION' is not a valid semver (expected MAJOR.MINOR.PATCH, e.g. 0.22.0)"
+    exit 1
+fi
+
+# Run from repo root regardless of where invoked.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PLUGIN_JSON="plugins/${PLUGIN_NAME}/.claude-plugin/plugin.json"
+MARKETPLACE_JSON=".claude-plugin/marketplace.json"
+
+if [ ! -f "$PLUGIN_JSON" ]; then
+    echo "ERROR: $PLUGIN_JSON not found (is the plugin name '$PLUGIN_NAME' correct?)"
+    exit 1
+fi
+
+# Use python3 for safe JSON edits (preserves structure, no regex foot-guns).
+OLD_VERSION="$(python3 - "$PLUGIN_JSON" "$MARKETPLACE_JSON" "$PLUGIN_NAME" "$NEW_VERSION" <<'PY'
+import json, sys
+plugin_path, market_path, plugin_name, new_version = sys.argv[1:5]
+
+with open(plugin_path) as f:
+    plugin = json.load(f)
+old = plugin.get("version")
+plugin["version"] = new_version
+with open(plugin_path, "w") as f:
+    json.dump(plugin, f, indent=2)
+    f.write("\n")
+
+with open(market_path) as f:
+    market = json.load(f)
+found = False
+for entry in market.get("plugins", []):
+    if entry.get("name") == plugin_name:
+        entry["version"] = new_version
+        found = True
+with open(market_path, "w") as f:
+    json.dump(market, f, indent=2)
+    f.write("\n")
+
+if not found:
+    sys.stderr.write(f"WARNING: no marketplace.json entry named '{plugin_name}' — only plugin.json was updated\n")
+print(old or "(unset)")
+PY
+)"
+
+echo "Synced '$PLUGIN_NAME': $OLD_VERSION -> $NEW_VERSION"
+echo "  updated: $PLUGIN_JSON"
+echo "  updated: $MARKETPLACE_JSON"
+echo ""
+echo "Next steps:"
+echo "  1. Add '## [$NEW_VERSION] - $(date +%Y-%m-%d)' to CHANGELOG.md"
+echo "  2. scripts/validate-plugin.sh"
+echo "  3. Commit + push + merge to main (the version bump is what propagates the update)."

--- a/scripts/validate-plugin.sh
+++ b/scripts/validate-plugin.sh
@@ -23,13 +23,13 @@ echo ""
 # Function to report error
 error() {
     echo -e "${RED}ERROR: $1${NC}"
-    ((ERRORS++))
+    ERRORS=$((ERRORS + 1))
 }
 
 # Function to report warning
 warning() {
     echo -e "${YELLOW}WARNING: $1${NC}"
-    ((WARNINGS++))
+    WARNINGS=$((WARNINGS + 1))
 }
 
 # Function to report success
@@ -225,6 +225,46 @@ if [ -f ".claude-plugin/marketplace.json" ]; then
     done
 else
     error "Missing marketplace.json"
+fi
+
+echo ""
+
+# 8. Check version consistency between marketplace.json entries and plugin.json files
+# WHY: auto-update is version-keyed; if these two disagree, the marketplace listing
+# and what actually installs can diverge. They must match for every plugin.
+echo "Checking version consistency (marketplace.json <-> plugin.json)..."
+echo "-------------------------------------------"
+
+if [ -f ".claude-plugin/marketplace.json" ]; then
+    CONSISTENCY_REPORT="$(python3 - <<'PY'
+import json, os
+with open(".claude-plugin/marketplace.json") as f:
+    market = json.load(f)
+for entry in market.get("plugins", []):
+    name = entry.get("name", "?")
+    mver = entry.get("version")
+    src = (entry.get("source") or "").lstrip("./")
+    pj = os.path.join(src, ".claude-plugin", "plugin.json")
+    if not src or not os.path.isfile(pj):
+        print(f"WARN|{name}|marketplace entry has no resolvable plugin.json at '{pj}'")
+        continue
+    with open(pj) as f:
+        pver = json.load(f).get("version")
+    if mver == pver:
+        print(f"OK|{name}|{pver}")
+    else:
+        print(f"ERR|{name}|marketplace={mver} plugin.json={pver}")
+PY
+)"
+    while IFS='|' read -r status name detail; do
+        case "$status" in
+            OK)   success "$name versions match ($detail)" ;;
+            WARN) warning "$name: $detail" ;;
+            ERR)  error "$name version mismatch: $detail (run scripts/sync-version.sh)" ;;
+        esac
+    done <<< "$CONSISTENCY_REPORT"
+else
+    error "Cannot check version consistency: marketplace.json missing"
 fi
 
 echo ""

--- a/scripts/validate-plugin.sh
+++ b/scripts/validate-plugin.sh
@@ -82,7 +82,7 @@ echo "-------------------------------------------"
 
 COMMAND_COUNT=0
 for cmd in $(find "$PLUGIN_DIR/commands" -name "*.md" 2>/dev/null); do
-    ((COMMAND_COUNT++))
+    COMMAND_COUNT=$((COMMAND_COUNT + 1))
     filename=$(basename "$cmd")
 
     # Check for frontmatter
@@ -118,7 +118,7 @@ echo "-------------------------------------------"
 
 AGENT_COUNT=0
 for agent in $(find "$PLUGIN_DIR/agents" -name "*.md" 2>/dev/null); do
-    ((AGENT_COUNT++))
+    AGENT_COUNT=$((AGENT_COUNT + 1))
     filename=$(basename "$agent")
 
     # Check for frontmatter
@@ -154,7 +154,7 @@ echo "-------------------------------------------"
 
 SKILL_COUNT=0
 for skill_dir in $(find "$PLUGIN_DIR/skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null); do
-    ((SKILL_COUNT++))
+    SKILL_COUNT=$((SKILL_COUNT + 1))
     skill_name=$(basename "$skill_dir")
 
     # Check for SKILL.md
@@ -196,7 +196,7 @@ echo "-------------------------------------------"
 
 TEMPLATE_COUNT=0
 for template in $(find "$PLUGIN_DIR/resources/templates" -name "*.md" 2>/dev/null); do
-    ((TEMPLATE_COUNT++))
+    TEMPLATE_COUNT=$((TEMPLATE_COUNT + 1))
     filename=$(basename "$template")
     success "Template exists: $filename"
 done


### PR DESCRIPTION
## Why

Claude Code marketplace auto-update is **version-keyed**: an install only re-pulls a plugin when its **version number changes**. So a content change shipped at an unchanged version silently never reaches users — even with `autoUpdate: true`.

That's exactly what happened: commit `914709f` (the "Out-of-Repo Changes" checkpoint feature) shipped at the same `0.21.0`, so every local install silently stayed stale. Separately, `marketplace.json` had drifted 4 versions behind `plugin.json` (0.17.0 vs 0.21.0).

## What this does

**Ships the latest to all installs**
- Bumps `plugin.json` + `marketplace.json` to **0.22.0** (reconciled — they now match)
- Backfills CHANGELOG `0.20.0` / `0.21.0` and adds `0.22.0`

**Makes the failure mode impossible to merge**
- `scripts/check-version-bump.sh` — fails if any plugin's files change vs base without a `plugin.json` bump (verified: catches the `914709f` scenario, passes when bumped)
- `scripts/validate-plugin.sh` — now asserts each `marketplace.json` entry version == its `plugin.json` version (+ fixed `set -e`-unsafe counters)
- `.github/workflows/plugin-guard.yml` — runs both on every PR/push to `main` (first CI in the repo)

**The sync flow, encoded**
- `scripts/sync-version.sh <version>` — bumps both manifests together so they can't drift
- `CLAUDE.md` "Versioning & Propagation" + Quality Checklist updated; README "Updating the Plugin" documents the version-keyed model

## Verification
- `validate-plugin.sh` → PASSED (0 errors / 0 warnings); all 3 plugins version-consistent
- `check-version-bump.sh` → PASS when bumped, **FAIL (exit 1)** on a simulated content-change-without-bump
- `sync-version.sh` → idempotent, version-only diffs, JSON stays valid

## Note on "fully automatic"
This is a marketplace-embedded plugin (relative-path source), so a machine may still need a one-time marketplace **Refresh** to pull a new version (documented in README). The version bump + guard guarantee updates are always *detectable and never silently skipped*; the refresh is the delivery step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)