### PR TITLE
improve: subagent dispatch hygiene + default activation-verification task

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.22.0"
+      "version": "0.22.1"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-07-11
+
+### Changed
+- **`autonomous-execution` skill — Subagent Dispatch Hygiene** — New section for multi-agent / shared-workspace execution: commit-producing subagents must stage explicit paths only (never repo-root `git add -A`), dispatch prompts must name foreign uncommitted files as never-stage, and the controller verifies each commit's `--name-only` file list against the task surface before recording it complete. Also: per-task reviewers receive the design doc (not just the brief) when briefs derive from one. From the 2026-07-07 agent-workforce retro (3rd/4th shared-workspace staging incidents).
+- **`tasks` template — default `[ACTIVATION]` task** — New "Activation & Wiring Verification" task included by default for anything that runs outside the repo after merge (cron, scheduled workflow, webhook, deployed service). Checklist requires evidence (read back the scheduler entry, confirm runtime config/deps, one end-to-end run from the runtime environment, failure-visibility check). 5th incident of the verify-cron/pipeline-wiring pattern.
+
 ## [0.22.0] - 2026-06-19
 
 ### Fixed

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/resources/templates/tasks.md
+++ b/plugins/product-playbook-for-agentic-coding/resources/templates/tasks.md
@@ -142,6 +142,29 @@
 
 ---
 
+### Task 1.A: Activation & Wiring Verification `[ACTIVATION]`
+> Use this format whenever the project delivers something that must run OUTSIDE the repo after merge — a cron job, scheduled workflow, webhook, deployed service, or background pipeline. **The merge is not the finish line; activation is.** Include this task by default for any such project and only delete it with a stated reason.
+
+**Description**: Verify the delivered thing actually runs in its runtime environment — merged code with missing runtime wiring fails silently.
+
+**Executor**: `[AGENT]` on the runtime machine/environment (or `[HUMAN]` if the agent lacks access)
+
+**Verification Checklist** (adapt to the runtime; every line needs evidence, not inference):
+- [ ] Scheduler entry exists (crontab/CI schedule/queue binding) — read it back, don't assume the install script added it
+- [ ] Runtime credentials/config present at the expected path (an EMPTY config dir fails silently)
+- [ ] Dependencies installed in the runtime checkout (not just the dev workspace)
+- [ ] One end-to-end run (dry-run mode if available) succeeds **from the runtime environment**
+- [ ] Failure visibility confirmed: where do errors surface (log path, alert channel), and would a silent failure be noticed?
+
+**Acceptance Criteria**:
+- [ ] Every checklist line verified with command output (the truth surface), not "the install script should have done it"
+
+**Status**: [ ] Not Started | [ ] In Progress | [ ] Complete
+
+> **Why this matters**: The "verify cron/pipeline wiring" pattern hit its 5th incident in the 2026-07-07 agent-workforce activation: an empty `~/.config/<workflow>/` dir, a missing crontab entry, and a stale dependency-install list — all silent, all post-merge, none caught by CI. Activation verification is a task, not an afterthought.
+
+---
+
 ### Task 1.2: [Task Name]
 **Description**: [Detailed task description - specific and actionable]
 

--- a/plugins/product-playbook-for-agentic-coding/skills/autonomous-execution/SKILL.md
+++ b/plugins/product-playbook-for-agentic-coding/skills/autonomous-execution/SKILL.md
@@ -195,6 +195,22 @@ Autonomous execution has a seductive failure mode: the agent's track is **always
 
 Don't let an always-available build queue become a comfortable proxy for harder, scarier real-world validation. (Found: acquisition-engine — 10 weeks of measurement infrastructure shipped, exactly **one** acquisition channel actually run. The agent never surfaced that the bottleneck had shifted; the founder later named it: *"building felt safer than posting."*)
 
+## Subagent Dispatch Hygiene (Multi-Agent / Shared-Workspace Execution)
+
+When executing via dispatched subagents (implementer-per-task patterns) — especially in shared working directories (Conductor workspaces, git worktrees used by parallel sessions):
+
+### Commit-surface verification (every commit-producing dispatch)
+
+1. **Dispatch instruction**: every subagent that commits must stage **explicit paths only** (`git add <files>`, or at widest `git add -A <task-dir>`). Never `git add -A` / `git commit -am` at repo root — in a shared workspace, foreign uncommitted files (another session's WIP) get silently swept into the commit.
+2. **Name the foreign files**: if the working tree contains uncommitted files from another session, list them in every dispatch prompt as never-stage.
+3. **Controller verification**: before recording a task complete, verify the reported commit's `git show --stat --name-only <sha>` against the task's expected file surface. A commit touching files outside the surface is a **failed task** requiring history repair (amend + `rebase --onto` + force-push), not a bookkeeping note.
+
+> Origin: 2026-07-07 agent-workforce retro — a fix-subagent's repo-wide staging swept another session's files into a commit; caught only at final whole-branch review, requiring history rewrite. Two prior shared-workspace incidents existed; per-incident recovery rules did not prevent the third.
+
+### Reviewer context (plan-derived tasks)
+
+When task briefs are derived from a design doc, give per-task **reviewers the design doc reference, not just the brief**. Plans narrow designs; implementers faithfully transcribe the narrower version; only a reviewer holding the design catches the fidelity gap. (Two contract gaps in the same retro were caught exactly this way; briefs alone would have passed both.)
+
 ## Quality Gates
 
 ### Pre-Commit Gates


### PR DESCRIPTION
Two systemic upgrades from the [agent-workforce hiring retrospective](https://github.com/daviswhitehead/chef-chopsky/blob/production/docs/learnings/2026-07-07-agent-workforce-hiring-retrospective.md):

**1. autonomous-execution skill — Subagent Dispatch Hygiene.** In shared workspaces, a fix-subagent's repo-wide staging swept another session's uncommitted files into a commit (caught only at final whole-branch review; required history rewrite — 3rd/4th shared-workspace incidents). New rules: explicit-path staging in every commit-producing dispatch, foreign files named as never-stage, and the controller verifies each commit's `--name-only` list against the task surface before recording it complete. Plus: per-task reviewers get the design doc (not just the brief) when briefs derive from one — two plan-narrowed contract gaps were caught exactly this way.

**2. tasks template — default `[ACTIVATION]` task.** 5th incident of the verify-cron/pipeline-wiring pattern: post-merge activation surfaced an empty config dir, a missing crontab entry, and a stale dependency-install list — all silent, none caught by CI. The template now includes an activation-verification task by default for anything that runs outside the repo after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)