### PR TITLE
improve(monitor-pr): audit SKIPPED checks before counting them green

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.22.1"
+      "version": "0.22.2"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.2] - 2026-07-11
+
+### Changed
+- **`/playbook:monitor-pr` — SKIPPED checks are conditionally green** — Step 1 no longer counts `COMPLETED + SKIPPED` as unconditionally green. A short audit distinguishes legitimate path-filter skips from never-armed suites: if the PR's diff touches the skipped job's path filter, the suite never ran (most common cause: PR created non-draft, so the one-shot `ready_for_review` full-CI trigger never fired) — arm full CI and re-run before classifying. Step 4's terminal all-green state requires SKIPPED checks to have passed the audit. From chef-chopsky PR #294: 6 weeks all-green while integration tests and evals were silently SKIPPED.
+
 ## [0.22.1] - 2026-07-11
 
 ### Changed

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
@@ -71,9 +71,21 @@ Classify each check into one of:
 
 | State | Action |
 |---|---|
-| `COMPLETED` + `SUCCESS` / `SKIPPED` / `NEUTRAL` | green — count it |
+| `COMPLETED` + `SUCCESS` / `NEUTRAL` | green — count it |
+| `COMPLETED` + `SKIPPED` | conditionally green — run the SKIPPED audit below |
 | `IN_PROGRESS` / `QUEUED` | waiting — go to Step 2 |
 | `COMPLETED` + `FAILURE` / `CANCELLED` / `TIMED_OUT` | red — go to Step 3 |
+
+**SKIPPED audit** — a skipped job is either a legitimate path-filter skip or a
+symptom that the full suite was never armed. Distinguish them before counting it green:
+
+1. Does the PR's diff touch the skipped job's path filter (e.g., integration/eval jobs
+   for `agent/**`, E2E for `frontend/**`)? If **no** → legitimate skip, count green.
+2. If **yes** → the suite never ran. Most common cause: the PR was **created non-draft**,
+   so a one-shot `ready_for_review` full-CI trigger never fired — the PR can sit for weeks
+   looking all-green while its required jobs stay SKIPPED (chef-chopsky PR #294: 6 weeks,
+   integration + evals skipped). Arm the full suite (e.g., `ci:full`-style label or the
+   project's equivalent), re-run, and only then classify.
 
 If **all green and nothing waiting**: jump to Step 4 (terminal).
 If **anything waiting and nothing red**: Step 2 (poll).
@@ -178,7 +190,8 @@ This saves ~17 min per iteration. **Do NOT use this for behavioral code changes*
 
 When `gh pr view --json statusCheckRollup` shows 0 non-success/skip checks:
 
-1. **Confirm** `mergeable: MERGEABLE` and `state: OPEN`.
+1. **Confirm** `mergeable: MERGEABLE` and `state: OPEN`, and that every SKIPPED check
+   passed the Step 1 SKIPPED audit (path-filter skip, not a never-armed suite).
 2. **Check the user's original prompt** for "merge ready" or "ready to review" language. If present and `isDraft: true`, run `gh pr ready <PR>` and wait for the full-CI run that triggers.
 3. **Report back** with:
    - PR URL


### PR DESCRIPTION
## What was learned

While shepherding chef-chopsky [PR #294](https://github.com/daviswhitehead/chef-chopsky/pull/294) to merge (2026-07-10 sun-valley close-out session), we found it had sat **6 weeks** with all-green checks while Integration Tests (Agent) and Agent Evals were silently **SKIPPED** — the PR was created non-draft, so the one-shot `ready_for_review` full-CI trigger never fired. `mergeable: MERGEABLE` / `mergeStateStatus: CLEAN` the whole time.

`monitor-pr` Step 1 classified `COMPLETED + SKIPPED` as unconditionally green, which would reproduce exactly this false-green.

## Changes

- **Step 1**: `SKIPPED` is now *conditionally green* — a short audit distinguishes legitimate path-filter skips from never-armed suites (diff touches the skipped job's paths → arm full CI and re-run before classifying).
- **Step 4**: terminal all-green state now requires SKIPPED checks to have passed that audit.

Companion codebase learning: chef-chopsky `docs/learnings/2026-06-30-stale-ci-on-long-open-prs.md` (2026-07-10 addendum, lands via chef-chopsky PR #399).

🤖 Generated with [Claude Code](https://claude.com/claude-code)