### PR TITLE
improve: valencia wrap-up learnings — critique triage tags, merged-fix verification, cron wiring criterion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.22.3"
+      "version": "0.22.4"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.4] - 2026-07-11
+
+### Changed
+- **`/playbook:critique` Step 3.3b — execution-triage tags** — Every P0/P1 finding gets `[AUTONOMOUS]` (fix now, same session), `[BLOCKED-ON-HUMAN]` (explicit sign-off checklist in the synthesis), or `[DEFERRED-BY-DESIGN]` (name where it lands). Severity says how much a finding matters; the tag says who can act on it. From the memory-vocab overnight critique pass: two P0 security fixes landed autonomously the same night while two DB-write P0s were correctly held for human sign-off.
+- **`/playbook:learnings` — "implemented" means MERGED** — The prior-learnings pre-check now verifies a prior fix reached the default branch (`git merge-base --is-ancestor` / `gh pr view`), not merely that a commit exists. The staging-migration-drift fix was fully implemented on a branch that never merged; six manual repair incidents followed.
+- **`tasks` template — cron/pipeline wiring criterion** — Tasks whose output comes from a scheduled/pipeline entrypoint must include an integration test that drives the REAL entrypoint and asserts the persisted side effect — not a test that seeds the output artifact. Second recurrence of the wiring gap (`summaries_generated=0` invisible for 24 days).
+
 ## [0.22.3] - 2026-07-11
 
 ### Changed

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/critique.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/critique.md
@@ -201,6 +201,16 @@ Find issues flagged by multiple personas—these are highest priority.
 - **P1 (Should Fix)**: Flagged by 2 personas OR high impact
 - **P2 (Nice to Fix)**: Single persona, lower impact
 
+**3.3b Tag Execution Triage** (required for code critiques; recommended for docs)
+
+Severity says how much a finding matters; the triage tag says **who can act on it**. Tag every P0/P1 finding:
+
+- `[AUTONOMOUS]` — the agent can fix it now without human judgment (e.g., wiring an existing guard, input sanitization, comment/doc fixes). Fix these in the same session; don't wait for review.
+- `[BLOCKED-ON-HUMAN]` — needs a human decision or privileged access (DB-write paths, schema/migration design, production data, budget/scope calls). List them as an explicit sign-off checklist in the synthesis.
+- `[DEFERRED-BY-DESIGN]` — correct to postpone (belongs to a later PR/phase). Name where it lands.
+
+**Why**: The memory-vocab PR-1/PR-2 critique (2026-05, chef-chopsky) triaged this way during overnight autonomous work: two P0 security fixes landed the same night ([AUTONOMOUS]) while two DB-write P0s were correctly held for human sign-off. Without the tags, autonomous sessions either stall on everything or overreach on production-data changes.
+
 **3.4 Generate Synthesis**
 
 Create synthesis document using template from `resources/templates/critique-synthesis.md`:

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -108,6 +108,7 @@ Recurring patterns detected:
 - "[pattern]" — appeared in [N] prior learnings ([dates/titles])
   → Prior proposed fix: [what was proposed before]
   → Was it implemented? [yes/no/partially]
+  → If "yes": did it actually MERGE? [verify — see below]
 
 These recurring patterns should be prioritized HIGHEST in this
 retrospective — they represent problems that documentation alone
@@ -121,6 +122,8 @@ workflow changes), not more documentation.
 Unimplemented improvement ideas from prior retrospectives:
 - [Idea] (from [date] learnings) — still relevant? [y/n]
 ```
+
+**"Implemented" means MERGED, not written.** When checking whether a prior fix landed, verify it reached the default branch — `git merge-base --is-ancestor <sha> origin/<default>` or `gh pr view` on its PR — not merely that a commit or file exists. The staging-migration-drift fix (chef-chopsky, 2026-04-10 `a675b6ca`) was fully implemented on a workspace branch that never merged; six manual repair incidents followed while every retrospective would have scored it "implemented." A fix on an unmerged branch is an unimplemented fix.
 
 **Why this matters**: Without this search, the same problems get documented repeatedly across retrospectives without escalation. A pattern that appears in 3 retrospectives needs a systemic fix, not a 4th documentation entry.
 

--- a/plugins/product-playbook-for-agentic-coding/resources/templates/tasks.md
+++ b/plugins/product-playbook-for-agentic-coding/resources/templates/tasks.md
@@ -113,6 +113,11 @@
 
 > **Why this matters**: A gate task that closes with one metric reading `null` is not passing — it's broken. The Memory & Personalization Phase 1 gate (2026-04-07) closed as "Conditional GO" with `$duration` unmeasurable for 4 weeks because the gate template didn't require instrumentation verification. The template change above closes that gap by making the instrumentation source and dry-run query mandatory fields.
 
+**Cron/pipeline wiring criterion** — for any task whose output is produced by a scheduled or pipeline entrypoint (cron handler, queue consumer, webhook), acceptance criteria MUST include:
+- [ ] An integration test drives the REAL entrypoint (e.g., the cron handler function) against seeded input and asserts the side effect persisted — NOT a test that seeds the output artifact and verifies the read path.
+
+> **Why**: Twice in the same project (Memory & Personalization: Phase 1 `$duration`, Phase 2c summaries), the module existed and its unit tests passed, but the runtime entrypoint never called it — `summaries_generated=0` was invisible for 24 days because tests seeded the artifact under test. Gate dry-runs catch this late; the wiring criterion catches it at task close.
+
 ---
 
 ### Task 1.H: [Human Task Name] `[HUMAN]`


### PR DESCRIPTION
## Summary

Plugin promotions from the chef-chopsky valencia worktree deep retrospective (see daviswhitehead/chef-chopsky#400 for the retrospective doc and the codebase-side systemic fix).

### 1. Critique workflow: execution-triage tags (Step 3.3b)
Every P0/P1 finding gets `[AUTONOMOUS]` / `[BLOCKED-ON-HUMAN]` / `[DEFERRED-BY-DESIGN]`. Grounded in the memory-vocab overnight critique pass: two P0 security fixes landed autonomously the same night, two DB-write P0s were correctly held for human sign-off. The tags make that triage explicit instead of ad hoc.

### 2. Learnings workflow: "implemented" means MERGED
The prior-learnings pre-check now verifies a prior fix reached the default branch (`git merge-base --is-ancestor` / `gh pr view`), not merely that a commit exists. Evidence: the staging-migration-drift auto-repair was fully implemented on 2026-04-10 (`a675b6ca`) on a branch that never merged; 6 manual repair incidents followed.

### 3. Tasks template: cron/pipeline wiring criterion
Tasks whose output comes from a scheduled/pipeline entrypoint must include an integration test that drives the REAL entrypoint and asserts the persisted side effect — not a test that seeds the output artifact. Second recurrence of the Memory & Personalization wiring gap (Phase 1 `$duration`, Phase 2c `summaries_generated=0` invisible for 24 days).

🤖 Generated with [Claude Code](https://claude.com/claude-code)