### PR TITLE
improve(close/learnings): check git stashes on close-out

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.22.2"
+      "version": "0.22.3"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.3] - 2026-07-11
+
+### Changed
+- **`/playbook:close` Phase 1 — stash check on close-out** — New step that runs even when the working tree is clean and every commit is pushed: `git stash list` entries tagged to the branch being closed are classified unique-vs-superseded (diff `HEAD <stash>` per file — a rebased/orphaned stash base makes `<base>..<stash>` misleading), salvaged to a pushed branch before dropping when unique/uncertain, and other branches' stashes are left alone. "All commits pushed" ≠ "everything is safe."
+- **`/playbook:learnings` branch-state pre-check** — Same stash check for standalone invocations; invocation from `/playbook:close` already covers it. From a real chef-chopsky close-out (2026-07-05) where a fully-pushed branch still held a 2-month-old WIP stash that would have been lost on archive.
+
 ## [0.22.2] - 2026-07-11
 
 ### Changed

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
@@ -32,6 +32,13 @@ You are facilitating an end-of-session close-out. Run each phase in order. Skip 
    - Offer to commit. If the user approves, draft a commit message and commit.
 4. If the working tree is clean: skip silently.
 
+5. **Stash check (do even when the working tree is clean and every commit is pushed).** A branch can have every commit in its PR yet still have work hiding in a `git stash` that vanishes when the worktree/branch is archived. "All commits pushed" ≠ "everything is safe." Run `git stash list` and look for entries whose label references the branch being closed (`stash@{N}: On <branch>: ...` or `WIP on <branch>: ...`).
+   - **For each stash tagged to this branch**, decide: is it unique work or already superseded by what's committed? Compare the stash's file versions against current `HEAD` — a rebased/orphaned stash base makes `git diff <base>..<stash>` misleading, so diff `HEAD <stash>` per file instead. For large diffs, dispatch a subagent so the comparison doesn't flood context.
+   - **If superseded** → safe to `git stash drop` (with the user's ok).
+   - **If unique or uncertain** → preserve it durably BEFORE dropping — you likely didn't create it. Salvage to a branch and push: `git branch <archive-name> stash@{N} && git push -u origin <archive-name>`. Then it's captured off the stash list and off this worktree; the user can review/discard later.
+   - **Leave stashes tagged to OTHER branches alone** — they're separate work streams; dropping them can destroy another effort's WIP.
+   - This closes a real gap: the working-tree check above catches uncommitted changes but not stashes. A user asking "is everything in the PR / safe to archive?" needs both checked.
+
 ## Phase 2: Task Cleanup
 
 1. Search for an active tasks document:

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -66,7 +66,9 @@ Before proceeding, consider what tools are available:
 
 2. **Branch was switched by another agent (parallel-agent workspaces — Conductor, git worktrees).** If multiple agents share a working directory, your session's branch may have been switched while you were sleeping/awaiting tools. Detect: compare `git branch --show-current` against the branch your session has been working on (last push target, PR head being monitored). If it's unfamiliar, stash any unrelated uncommitted changes (`git stash push -m "other-agent-WIP" <paths>`) and create a fresh branch off the target before continuing. Restore the stash after.
 
-If `/playbook:learnings` was invoked from `/playbook:close`, the close skill's Phase 1 already runs an equivalent check — you can skip this. For standalone invocations or after long wait gaps, run it.
+3. **Work hiding in a stash.** A branch can have every commit pushed yet still have uncommitted work in a `git stash` that's lost when the worktree/branch is archived. Before treating the branch as "everything captured," run `git stash list` and check for entries tagged to it (`On <branch>:` / `WIP on <branch>:`). For each: compare against `HEAD` (diff `HEAD <stash>` per file, not `<base>..<stash>` — the base may be rebased away); if superseded, drop it; if unique/uncertain, salvage to a pushed branch before dropping. Leave other branches' stashes alone.
+
+If `/playbook:learnings` was invoked from `/playbook:close`, the close skill's Phase 1 already runs an equivalent check (including the stash check) — you can skip this. For standalone invocations or after long wait gaps, run it.
 
 ### Pre-Check: CLAUDE.md Size Health (ALL Trigger Types)
 


### PR DESCRIPTION
## Problem

`/playbook:close` Phase 1 checks the working tree for uncommitted changes but never checks `git stash list`. A branch can have **every commit in its PR** yet still hold work in a stash that vanishes when the worktree/branch is archived — so "all commits pushed" ≠ "everything is safe."

This surfaced in a real close-out (chef-chopsky `memory-ui-docs`, 2026-07-05): the branch was fully pushed, but a `git stash` tagged to it held a 2-month-old WIP snapshot that would have been lost on archive. It was found only because the user asked "are you sure everything's in the PR?" twice.

## Change

- **`close.md` Phase 1**: new stash-check step that runs **even when the working tree is clean and every commit is pushed**. It identifies stashes tagged to the branch, decides unique-vs-superseded (diff `HEAD <stash>` per file — a rebased/orphaned base makes `<base>..<stash>` misleading), salvages-before-dropping when unique/uncertain, and leaves other branches' stashes alone.
- **`learnings.md` branch-state pre-check**: same stash check for standalone invocations; notes that invocation-from-`close` already covers it.

10 insertions, 1 deletion — pure guidance, no behavioral code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)