### PR TITLE
chore: session checkpoint — merge-open-prs close-out

### DIFF
--- a/docs/checkpoints/latest.md
+++ b/docs/checkpoints/latest.md
@@ -1,40 +1,40 @@
 # Session Checkpoint
-**Date**: 2026-06-20 02:27
-**Branch**: daviswhitehead/google-tasks-mcp-plugin
+**Date**: 2026-07-17 (session spanned 2026-07-11 → 2026-07-12 UTC)
+**Branch**: daviswhitehead/merge-open-prs (even with origin/main)
 
 ## Current Task
-Enable Claude to create Google Tasks as a cross-project, reusable capability in the plugin repo. Shipped as PR #49.
+Merge all open PRs in the plugin repo. Complete — zero open PRs remain.
 
 ## Status
 - **Done this session**:
-  - Confirmed no first-party Google Tasks MCP connector exists (Gmail/Drive/Calendar/Chat/People only; `tasksmcp.googleapis.com` 404s) — no-code path unavailable.
-  - Built new sibling plugin `plugins/google-tasks/`: zero-dependency stdio MCP server exposing `create_google_task` + `list_google_task_lists`.
-  - Pivoted implementation from custom OAuth/REST → wrapping the existing `gog` CLI (Option C), reusing gog's Keychain auth; no Google Cloud Console setup, no secrets stored by the plugin.
-  - Verified live against a real Google account (create + read-back + list); cleaned up all test tasks.
-  - Fixed two bugs found in testing: `tasklists`-key list parsing; and addressed a security finding (argv flag smuggling) via `--` option terminator + listId charset validation + `--flag=value` form.
-  - Opened PR #49.
-- **In progress**: none — feature complete and verified.
+  - Merged all 4 open PRs, oldest first, each with its own version bump + CHANGELOG entry so the plugin-guard passed and the update propagates: #51 → 0.22.1 (subagent dispatch hygiene + `[ACTIVATION]` task), #52 → 0.22.2 (monitor-pr SKIPPED audit), #54 → 0.22.3 (close-out stash check), #53 → 0.22.4 (critique triage tags, "implemented means MERGED", cron wiring criterion).
+  - #53 was draft; user approved proceeding — marked ready, merged main in (clean auto-merge with #51/#54's changes to the same files, verified), then merged.
+  - Housekeeping: removed leftover `/private/tmp/playbook-monitor-pr-fix` worktree; moved `~/GitHub/product-playbook-for-agentic-coding-plugin` off a merged branch back to `main` and fast-forwarded; pruned remote refs; safe-deleted (`-d`) 13 fully-merged local `improve/*` branches. Left all `daviswhitehead/*` branches alone (may belong to other Conductor workspaces).
+- **In progress**: nothing.
 - **Blocked on**: nothing.
 
 ## Key Decisions
-- **Wrap `gog` instead of custom OAuth (Option C)**: reuses existing, trusted auth infra (also used by OpenClaw), eliminates Cloud Console setup, keeps the plugin secret-free, while still exposing a structured MCP tool.
-- **Standalone sibling plugin** (mirrors `openai-image-gen`) rather than folding into the main product-playbook plugin — keeps the orthogonal capability independently installable.
-- **Security**: list id is a positional → passed after `--`; title/notes/due are `--flag=value` (safe values, allow leading `-`).
+- **PATCH bumps (0.22.1–0.22.4), one per PR**: all changes were guidance edits to existing files — no new commands/agents/skills, so PATCH per CLAUDE.md rules; per-PR versions keep CHANGELOG↔PR mapping 1:1 and let each merge pass the guard independently.
+- **Merge commits** (not squash), matching the repo's existing history style.
+- **Worktree conflicts**: PR branches checked out elsewhere (`~/GitHub`, `/tmp`) were handled via temp local branches + `git push origin HEAD:<branch>` — never touched the other checkouts until after merge.
 
 ## Open Questions
-- claude.ai cannot reach a local stdio server, so Tasks remains Claude Code-only until/unless Google ships a first-party remote Tasks connector. Acceptable per the goal's framing; revisit if a connector appears.
+- Two old stashes exist in the shared repo: `stash@{0}` (WIP on `daviswhitehead/git-cleanup`) and `stash@{1}` (WIP on `main`, very old). Left alone per the stash-check rule (tagged to other branches), but worth triaging someday.
 
 ## Next Steps
-1. Review/merge PR #49.
-2. After merge: update the marketplace, enable the `google-tasks` plugin, restart Claude Code.
-3. Optional: add `complete_google_task` / due-time support if needed (currently create + list only).
+1. Installed machines pick up 0.22.4 via version-keyed auto-update; refresh the marketplace on any machine that doesn't (README → "Updating the Plugin").
+2. Optional: triage the two old stashes above.
+3. Optional: archive this Conductor workspace — branch is even with origin/main, nothing local-only.
 
-## Hot Files (created this session)
-- `plugins/google-tasks/mcp/server.mjs`: zero-dep MCP stdio server (handshake, tools/list, tools/call, in-flight drain on stdin close).
-- `plugins/google-tasks/mcp/google-tasks-client.mjs`: thin wrapper over `gog` (binary resolution, `--` terminator, listId validation, JSON unwrap incl. `tasklists`).
-- `plugins/google-tasks/.mcp.json`, `.claude-plugin/plugin.json`, `commands/setup.md`, `skills/google-tasks/SKILL.md`, `README.md`.
-- `.claude-plugin/marketplace.json`: registered the plugin.
+## Hot Files (modified this session)
+- `plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json`: 0.22.0 → 0.22.4 (via four sequential bumps on the PR branches).
+- `CHANGELOG.md`: added 0.22.1–0.22.4 sections.
+- (Content changes came from the four merged PRs, not authored here.)
+
+## Out-of-Repo Changes (runtime / system / external)
+- Removed git worktree `/private/tmp/playbook-monitor-pr-fix` (was clean, branch merged).
+- `~/GitHub/product-playbook-for-agentic-coding-plugin` switched from `improve/close-out-stash-check` to `main` and fast-forwarded to 7cda1da.
 
 ## Context the Next Session Needs
-- Activation requires a one-time user step: `gog auth add <email> --services tasks` (browser consent; token in Keychain), then restart Claude Code. The MCP server resolves `gog` from `/opt/homebrew/bin` etc. (handles Claude Code's minimal PATH); override with `GOG_BIN`. Multi-account: set `GOOGLE_TASKS_ACCOUNT`.
-- gog quirk: a `--title` value starting with `-` must use `--title=value` form (already handled in the client).
+- The plugin-guard CI (`check-version-bump.sh`) is why every plugin-content PR must bump the version before merge — all four PRs sat red on exactly this. The bump-on-the-PR-branch-then-merge pattern used here works cleanly and sequentially.
+- `gh pr checkout` fails if the branch is checked out in any other worktree of the shared repo; use `git checkout -b tmp/x origin/<branch>` + `push origin HEAD:<branch>` instead. Also, `gh pr merge --delete-branch` silently switches your local checkout to `main`.


### PR DESCRIPTION
Docs-only checkpoint from the session that merged PRs #51–#54 (0.22.1 → 0.22.4) and did the post-merge housekeeping. No plugin content changes, so no version bump required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)