### PR TITLE
improve(monitor-pr): shared-worktree merge mechanics + stacked-bump release guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.22.4"
+      "version": "0.22.5"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.5] - 2026-07-17
+
+### Changed
+- **`/playbook:monitor-pr` — shared-worktree mechanics** — Two additions from the merge-open-prs session: (1) Step 3 documents the "PR branch held by another worktree" pattern (`gh pr checkout` fails when any worktree of the shared repo holds the branch; verify the other checkout is clean, then temp branch + `git push origin HEAD:<branch>` — never disturb a possibly-live session's worktree); (2) Step 4 warns that `gh pr merge --delete-branch` silently switches the local checkout to the default branch — re-checkout your working branch afterwards in parallel-agent workspaces.
+
 ## [0.22.4] - 2026-07-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,18 @@ can run them locally:
 - `scripts/check-version-bump.sh [base-ref]` — fails if any plugin's files changed
   versus the base branch without a `plugin.json` version bump.
 
+### Merging multiple open PRs (stacked bumps)
+
+When several content PRs are open at once, none will pass the guard until each
+bumps the version — and they can't all claim the same number. Merge them
+**sequentially, oldest first, one patch version per PR**: check out the PR
+branch (if another worktree holds it, use a temp branch + `git push origin
+HEAD:<branch>`), merge `origin/main` in, run `scripts/sync-version.sh
+<next-patch>`, add the CHANGELOG section, push, wait for the guard, merge, then
+repeat for the next PR against the new main. This keeps CHANGELOG↔PR mapping
+1:1 and lets every merge pass the guard independently. (Proven on the 2026-07
+four-PR backlog: 0.22.1 → 0.22.4.)
+
 ### Delivering an update to installed machines
 
 Because this is a marketplace-embedded plugin (plugin source is a relative path

--- a/docs/learnings/2026-07-17-merging-stacked-prs-across-worktrees.md
+++ b/docs/learnings/2026-07-17-merging-stacked-prs-across-worktrees.md
@@ -1,0 +1,60 @@
+---
+title: "Merging stacked guard-blocked PRs across shared worktrees"
+date: 2026-07-17
+trigger: chat-session
+analysis-depth: standard
+category: workflow
+tags: [git, worktrees, gh-cli, version-bump, plugin-guard, conductor, parallel-agents]
+severity: medium
+module: "release-process"
+---
+
+# Merging stacked guard-blocked PRs across shared worktrees
+
+## Context
+
+Session goal: merge all 4 open PRs (#51–#54). All were red on exactly one check — the
+version-bump guard — because none bumped the plugin version. Two of the four PR branches
+were also checked out in *other* worktrees of the shared repo (the `~/GitHub` main
+checkout and a leftover `/private/tmp` worktree), and this repo is worked on by parallel
+Conductor agent sessions.
+
+## Key Learnings
+
+### 1. Stacked guard-blocked PRs → sequential per-PR patch bumps
+
+Multiple open content PRs can't all pass the guard at once (each needs a bump, and they
+can't share a version number). The clean pattern: merge oldest-first, one patch version
+per PR — merge `origin/main` into the PR branch, `scripts/sync-version.sh <next-patch>`,
+CHANGELOG section, push, wait for guard, merge, repeat against the new main. Proven here
+as 0.22.1 → 0.22.4 with zero conflicts and a 1:1 CHANGELOG↔PR mapping. Promoted to
+CLAUDE.md ("Merging multiple open PRs").
+
+### 2. PR branches held by other worktrees
+
+`gh pr checkout` fails with "already used by worktree at <path>" when any worktree of the
+shared repo holds the branch. Don't disturb the other checkout (it may be a live agent
+session): verify it's clean and at the PR head, then work from a temp branch
+(`git checkout -b tmp/prN origin/<branch>` … `git push origin HEAD:<branch>`). Promoted
+to `/playbook:monitor-pr` Step 3.
+
+### 3. `gh pr merge --delete-branch` silently switches your checkout
+
+After deleting the PR branch it checks out the default branch and pulls — in a
+parallel-agent workspace this strands the session on `main` without warning. Re-checkout
+your working branch after merging. If another worktree holds the branch, the local delete
+fails harmlessly (remote still deleted), leaving that checkout on a remote-less branch.
+Promoted to `/playbook:monitor-pr` Step 4.
+
+### Bonus observation
+
+Conductor renames the workspace branch when a session is named (reflog showed
+`renamed refs/heads/daviswhitehead/puebla to refs/heads/daviswhitehead/merge-open-prs`) —
+if `git checkout <remembered-branch>` fails mid-session, check `git reflog` for a rename
+before assuming the branch is gone.
+
+## Action Items
+
+- [x] CLAUDE.md: "Merging multiple open PRs (stacked bumps)" section
+- [x] `/playbook:monitor-pr`: worktree-held-branch pattern (Step 3) + post-merge local-state note (Step 4)
+- [x] Session memory: worktree pattern cached for future sessions

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
@@ -129,6 +129,8 @@ gh run view <RUN_ID> --log-failed > /tmp/failed-<RUN_ID>.log
 
 Read each log end-to-end, not just the first error.
 
+**PR branch held by another worktree** (parallel-agent workspaces — Conductor, git worktrees): `gh pr checkout <N>` fails with "already used by worktree at <path>" when any other worktree of the shared repo has the branch checked out. Don't disturb that worktree (it may be a live session). Instead: verify it's clean and at the PR head (`git -C <path> status --short`), then work from a temp branch — `git checkout -b tmp/pr<N> origin/<branch>`, commit your fix, `git push origin HEAD:<branch>`. Delete the temp branch after merge.
+
 #### 3a. Triage (delegate to `/playbook:debug-ci` Step 0)
 
 For each failure, classify:
@@ -199,6 +201,8 @@ When `gh pr view --json statusCheckRollup` shows 0 non-success/skip checks:
    - Estimated Actions minutes consumed (runs × typical durations)
    - Whether `isDraft` is now false (relevant if user said "merge ready")
    - Confirmation it's ready to merge (and if user pre-approved, run `gh pr merge --squash --delete-branch`)
+
+> **Post-merge local state**: `gh pr merge --delete-branch` silently switches your local checkout to the default branch (and pulls) after deleting the PR branch. In a parallel-agent workspace this can strand your session on the wrong branch — re-checkout your working branch afterwards. If another worktree holds the PR branch, the local delete fails with a warning; that's harmless (the remote branch is still deleted), but the other checkout is left on a branch that no longer exists remotely — worth flagging for cleanup.
 
 ### Step 5: False-Green Sanity Check
 


### PR DESCRIPTION
## What was learned

While merging the 4-PR backlog (#51–#54 → 0.22.1–0.22.4, 2026-07 merge-open-prs session), three shared-worktree mechanics bit in practice; this PR promotes them to point-of-use.

## Changes

- **`/playbook:monitor-pr` Step 3** — *PR branch held by another worktree*: `gh pr checkout` fails when any worktree of the shared repo holds the branch (hit on 2 of 4 PRs). Pattern: verify the other checkout is clean and at the PR head, then temp branch + `git push origin HEAD:<branch>` — never disturb a possibly-live session's worktree.
- **`/playbook:monitor-pr` Step 4** — *post-merge local state*: `gh pr merge --delete-branch` silently switches the local checkout to the default branch; re-checkout your working branch afterwards in parallel-agent workspaces.
- **CLAUDE.md** — *Merging multiple open PRs (stacked bumps)*: sequential oldest-first per-PR patch bumps, since concurrent content PRs can't all pass the guard at the same version.
- **docs/learnings** — session write-up with evidence ([2026-07-17-merging-stacked-prs-across-worktrees.md](https://github.com/daviswhitehead/product-playbook-for-agentic-coding-plugin/blob/improve/merge-open-prs-session-learnings/docs/learnings/2026-07-17-merging-stacked-prs-across-worktrees.md) — lands on main with this PR).

Bump: 0.22.4 → 0.22.5 (patch — guidance edits only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)