### PR TITLE
feat(playbook): instrumentation acceptance is the metric, not the event

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.22.5"
+      "version": "0.23.0"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`tasks` template — `[INSTRUMENTATION]` task format** — Any task adding or changing an analytics event, metric, pixel, or telemetry now declares both **Emission** (where data is produced) and **Consumption** (the exact consuming query, its expected non-null result, and its actual pasted output). Acceptance is the metric reading correctly, not the event firing. Also requires the attribute to live on the same record the metric counts (or explicit justification for the join), plus a runnable regression check validated in *both* directions.
+
+### Changed
+- **Instrumentation acceptance = run the consuming query** (`autonomous-execution` skill, `delivery-agent`, `/playbook:work`, `tasks` template) — Emission and metric correctness are now explicitly two separate checks. The prior gate accepted "confirm it lands in the truth surface (PostHog/analytics/the metric query)", which let *emission* satisfy the whole gate — the exact loophole that fired. A 202 from the endpoint, a DevTools network request, a green unit test asserting the tracking call, and the event visible in a live-events stream are all compatible with a metric that reads zero forever.
+
+  Fourth recurrence of this family (after Memory Phase 1 `null` gate metrics, the `summaries_generated=0` wiring gap, and acquisition `recipe_cta_clicked` at zero events for 12 days). This time an ad conversion pixel passed every emission check — SDK loaded on both hosts, event accepted 202, attribution param on the payload, person properties written correctly, unit tests green — and shipped. The consuming query read a property path the event never carried (the event is captured server-side; that path only exists on client captures), so every signup bucketed as "direct (no UTM)". Caught in a pre-launch audit one click before a paid campaign would have spent its full budget for zero attribution, which ad platforms cannot backfill.
+
 ## [0.22.5] - 2026-07-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-07-25
+
 ### Added
 - **`tasks` template — `[INSTRUMENTATION]` task format** — Any task adding or changing an analytics event, metric, pixel, or telemetry now declares both **Emission** (where data is produced) and **Consumption** (the exact consuming query, its expected non-null result, and its actual pasted output). Acceptance is the metric reading correctly, not the event firing. Also requires the attribute to live on the same record the metric counts (or explicit justification for the join), plus a runnable regression check validated in *both* directions.
 

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.22.5",
+  "version": "0.23.0",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/agents/workflow/delivery-agent.md
+++ b/plugins/product-playbook-for-agentic-coding/agents/workflow/delivery-agent.md
@@ -80,7 +80,40 @@ After completing implementation:
 - [ ] Linting passes
 - [ ] Build succeeds
 - [ ] All acceptance criteria met
+- [ ] **If instrumentation**: the consuming query was RUN and returned a correct
+      non-null value — output pasted into the completion notes (see below)
 ```
+
+#### Instrumentation tasks: the metric is the acceptance criterion
+
+If the task adds or changes any analytics event, metric, tracking pixel, or
+telemetry, **emission evidence is not acceptance**. Each of these is
+insufficient on its own:
+
+- a 200/202 from the analytics or ad endpoint
+- a visible network request in DevTools
+- a passing unit test asserting the tracking function was called
+- the event appearing in a live-events stream
+
+All four are fully compatible with a metric that reads zero forever. Run the
+query, dashboard, or report that **consumes** the data and confirm it returns a
+correct non-null value. Paste that output as the completion evidence.
+
+If no consumer exists yet, the task is not done — write the query. Prefer
+putting the attribute on the same event the metric counts, so no join or
+person-property lookup is needed. Where a pipeline owns its queries, add a check
+that runs them against real data and fails on an empty/null result — and
+validate it in **both** directions, since a check that can't fail on the old
+broken version is a rubber stamp.
+
+> Real incident: an ad conversion pixel was verified end to end — SDK loaded,
+> event accepted with 202, person properties written correctly, unit tests green
+> — and shipped. The query consuming it read a property path the event never
+> carried, so every signup bucketed as "direct (no UTM)". Code review couldn't
+> see it because nothing had ever run the query against an attributed signup.
+> Caught during a pre-launch audit, one click before a paid campaign would have
+> spent its full budget for zero attribution — which that platform cannot
+> backfill.
 
 ### Phase 5: Complete Task
 

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/work.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/work.md
@@ -259,6 +259,17 @@ Acceptance criteria: [list from tasks doc]"
    - Validate functionality manually if needed
 3. Fix any issues found
 
+**If the task touched instrumentation** (any analytics event, metric, tracking
+pixel, or telemetry), verification is NOT "the event fired." Run the query,
+dashboard, or report that **consumes** the data and confirm it returns a correct
+non-null value, then paste that output as the evidence.
+
+A 202 from the endpoint, a network request in DevTools, a green unit test
+asserting the tracking call, and the event appearing in a live-events stream are
+all compatible with a metric that reads zero forever. If no consumer exists yet,
+the task is not done — write the query. See the `[INSTRUMENTATION]` task format
+in `resources/templates/tasks.md`.
+
 
 ### Step 5.5: Autonomous Pre-Review (Agent Dry-Run)
 

--- a/plugins/product-playbook-for-agentic-coding/resources/templates/tasks.md
+++ b/plugins/product-playbook-for-agentic-coding/resources/templates/tasks.md
@@ -81,6 +81,7 @@
 - [ ] **CRITICAL**: ALL acceptance criteria checkboxes above are marked
 - [ ] All dependencies are satisfied
 - [ ] Completion notes added below
+- [ ] **If this task touches instrumentation** (any event, metric, pixel, or telemetry): the CONSUMING query was run and returned a correct non-null value, and its output is pasted in the notes. See the `[INSTRUMENTATION]` task format below — "the event fired" is not acceptance.
 
 **Notes**: [Any relevant notes or blockers]
 
@@ -117,6 +118,38 @@
 - [ ] An integration test drives the REAL entrypoint (e.g., the cron handler function) against seeded input and asserts the side effect persisted — NOT a test that seeds the output artifact and verifies the read path.
 
 > **Why**: Twice in the same project (Memory & Personalization: Phase 1 `$duration`, Phase 2c summaries), the module existed and its unit tests passed, but the runtime entrypoint never called it — `summaries_generated=0` was invisible for 24 days because tests seeded the artifact under test. Gate dry-runs catch this late; the wiring criterion catches it at task close.
+
+---
+
+### Task 1.I: [Instrumentation Task Name] `[INSTRUMENTATION]`
+> Use this format for any task that adds or changes an analytics event, metric, tracking pixel, or telemetry. **The acceptance criterion is the metric reading correctly — not the event firing.**
+
+**Description**: [What is being measured and which decision it informs]
+
+**Emission** (where the data is produced):
+- Event/signal: [`event_name`, pixel call, log line]
+- Call site(s): [`path/to/file.ts:LINE`]
+- Attributes carried: [list — and note whether they ride on the EVENT or on a separate person/user record]
+
+**Consumption** (where the number is read — REQUIRED, not optional):
+| Consumer | Exact query / dashboard | Expected non-null result | Actual result | Date verified |
+|---|---|---|---|---|
+| [e.g. `workflows/.../fetch-metrics.ts`] | [paste the exact query string] | [e.g. a real channel name, not "unknown"] | [paste the real output] | [Date] |
+
+**Acceptance Criteria**:
+- [ ] Emission verified (event/signal reaches the destination)
+- [ ] **The consuming query was RUN and returned a correct non-null value** — actual output pasted above
+- [ ] The attribute lives on the same record the metric counts, OR the join/lookup is explicitly justified (races and NULLs live in joins)
+- [ ] A regression check exists that runs the consuming query against real data and fails on empty/null
+- [ ] That check was validated in BOTH directions — it fails when pointed at the old/broken version
+
+**Status**: [ ] Not Started | [ ] In Progress | [ ] Complete
+
+> **Why this matters**: Emission evidence and metric correctness are independent. A 202 from the analytics endpoint, a network request in DevTools, a green unit test asserting the tracking call, and the event showing in a live-events stream are **all** compatible with a metric that reads zero forever.
+>
+> A conversion pixel was verified end to end — SDK loaded, event accepted 202, person properties written correctly, unit tests green — and marked done. The consuming query read a property path the event never carried, so every signup bucketed as "direct (no UTM)". Code review couldn't catch it because nothing had run the query against a real attributed signup. Found in a pre-launch audit, one click before a paid campaign would have spent its full budget for zero attribution — which ad platforms cannot backfill.
+>
+> If no consumer exists yet, the task is not done: write the query.
 
 ---
 

--- a/plugins/product-playbook-for-agentic-coding/skills/autonomous-execution/SKILL.md
+++ b/plugins/product-playbook-for-agentic-coding/skills/autonomous-execution/SKILL.md
@@ -122,10 +122,27 @@ After completing each task:
 If a task's acceptance criterion includes **"event fires", "metric captured", "instrumentation added", or "tracked in <analytics tool>"**, the task **cannot be marked complete on a static/import check** ("the code calls `capture()`", "imports are clean"). Code-is-wired ≠ behavior-verified.
 
 Before marking such a task ✅, require ONE of:
-1. **Runtime evidence** — fire the event yourself (synthetic click in a browser / incognito + DevTools network filter) and confirm it lands in the truth surface (PostHog/analytics/the metric query), OR
+1. **Runtime evidence AND metric evidence** — the two-part rule below, OR
 2. **An explicit unverified flag** surfaced to the user: *"Code is wired but I could not verify the event fires at runtime — needs a runtime check before this is truly done."*
 
 Never silently equate the two. This failure mode has recurred across three projects (Memory Phase 1 gates closed with `null` metrics; acquisition T10/T11/T12 closed with zero/deprecated events — `recipe_cta_clicked` logged **zero events for 12 days** after being marked done on "imports are clean"). The symptom of a miss is "No data recorded" for a *shipped* event — treat that as instrumentation-suspect, not "no traffic," and fire a synthetic event to disambiguate.
+
+#### Emission and the metric are two separate checks
+
+"It landed in the analytics tool" is **emission**, not the metric. Verify both:
+
+1. **Emission** — fire the event yourself (synthetic click / incognito + DevTools network filter) and confirm it arrives.
+2. **The metric** — run the query, dashboard, or report that **consumes** the data and confirm it returns a **correct non-null value**. Paste that output as the evidence.
+
+Step 2 is the one that gets skipped, and skipping it is invisible. A 202 from the endpoint, a network request in DevTools, a green unit test asserting the tracking call, and the event visible in a live-events stream are **all** compatible with a metric that reads zero forever.
+
+> A conversion pixel passed step 1 completely — SDK loaded on both hosts, event accepted 202, attribution param on the payload, person properties written correctly, unit tests green — and was marked done. The consuming query read a property path the event never carried (the event is captured server-side; that path only exists on client captures), so every signup bucketed as "direct (no UTM)". Nothing had run the query against a real attributed signup, so code review couldn't see it. Found in a pre-launch audit, one click before a paid campaign would have spent its full budget for zero attribution — which ad platforms cannot backfill.
+
+Two habits that prevent this class:
+- **Put the attribute on the same record the metric counts.** Joins and person-property lookups are where NULLs and read-time races hide.
+- **Make the consuming query a runnable check** that fails on an empty/null result, and validate it in **both** directions — a check that doesn't fail when pointed at the old broken version is a rubber stamp, not a guard.
+
+If no consumer exists yet, the task is not done: write the query.
 
 ### Acknowledge Method Substitution (don't silently downgrade verification)
 


### PR DESCRIPTION
Emission and metric correctness are two independent checks, and the playbook only enforced the first.

## The loophole

The instrumented-task gate in `autonomous-execution` said:

> confirm it lands in the truth surface (PostHog/analytics/**the metric query**)

That parenthetical made the metric query one option among equals, so "the event landed in PostHog" satisfied the whole gate. That is exactly the loophole that fired.

## What changed

| File | Change |
|---|---|
| `resources/templates/tasks.md` | New **`[INSTRUMENTATION]`** task format: declares **Emission** (event, call sites, and whether attributes ride on the event or a separate person record) *and* **Consumption** (exact query, expected non-null result, actual pasted output, date verified) |
| `resources/templates/tasks.md` | Generic Completion Verification gains an instrumentation line pointing at that format |
| `skills/autonomous-execution/SKILL.md` | Splits the gate into **Emission** and **The Metric** as separate numbered checks; names the four false-green signals; adds two prevention habits |
| `agents/workflow/delivery-agent.md` | Validation-checklist item + a section on why emission evidence isn't acceptance |
| `commands/workflows/work.md` | Step 5 instrumentation branch |
| `CHANGELOG.md` | Unreleased entry |

The new acceptance criteria also require:
- the attribute to live on **the same record the metric counts** (or an explicit justification for the join — joins and person-property lookups are where NULLs and read-time races hide)
- a regression check validated in **both** directions, since a check that can't fail on the old broken version is a rubber stamp

## Why now — fourth recurrence

After Memory Phase 1 `null` gate metrics, the `summaries_generated=0` wiring gap, and acquisition `recipe_cta_clicked` at zero events for 12 days.

This time an ad conversion pixel passed **every** emission check — SDK loaded on both hosts, event accepted with 202, attribution param present on the payload, person properties written correctly, unit tests green — and was marked done. The consuming query read `properties.$set.acquisition_channel` off an event captured **server-side**, and server captures carry no `$set`. Every signup bucketed as `"direct (no UTM)"` across all **95/95** historical events.

Code review couldn't see it because nothing had ever run the query against an attributed signup.

Caught in a pre-launch audit one click before a $50 campaign would have spent out for zero attribution — which ad platforms cannot backfill.

The generalizable lesson isn't "check PostHog." It's **run the query that produces the number you plan to make a decision with.**

## Companion work

Implemented in the consuming repo alongside this:
- the query fix + a live `verify-metrics-queries.ts` check (validated in both directions — passes on the fix, exits 1 on the old query)
- a sharpened `CLAUDE.md` rule distinguishing the metric from the event

🤖 Generated with [Claude Code](https://claude.com/claude-code)