### PR TITLE
feat(playbook): negative-test every guardrail; catch stale CLAUDE.md rules (0.24.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.23.3"
+      "version": "0.24.0"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-07-25
+
+### Added
+- **`autonomous-execution` — "Negative-test every guardrail you add"** — promoted from an instrumentation-only acceptance criterion to a general principle covering ANY guard: lint rules, CI jobs, hooks, schema audits, quality gates, assertion helpers. A guard must be run twice — positive, and against the broken input it exists to catch — and seen to fail with an actionable message. Also warns about guards that become *unsatisfiable* by inheriting a production filter that removes their own fixture. Mirrored as a checkbox in the `tasks` template's Completion Verification.
+
+  This rule was written down after a 2026-05-16 incident (a CI guardrail that never fired) and lived **only in a retrospective for two months** — so the next two guardrails repeated it, including one in the same session that produced this change. Documentation had already failed twice; this puts it in the workflow.
+
+### Changed
+- **`/playbook:learnings` demotion checklist — "Is every rule still TRUE?"** — trimming CLAUDE.md previously only looked for *resolved*, *niche*, *duplicated*, or *stale-milestone* content. It never asked whether a rule was still factually correct. Found 2026-07-25: CLAUDE.md told agents to add new E2E specs to Playwright's `testMatch`, but the config had become a deny-list where specs enroll automatically — an actively misleading rule costing context in every session. A wrong rule is worse than a missing one; delete rather than demote.
+- **`/playbook:learnings` — trimming safety note** — back up CLAUDE.md before `git checkout -- CLAUDE.md`; it restores from the index and silently discards unstaged trims (hit during the 2026-07-25 retro, costing a full redo).
+
 ## [0.23.3] - 2026-07-25
 
 ### Added

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.23.3",
+  "version": "0.24.0",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -554,7 +554,10 @@ The primary CLAUDE.md size check now runs in **Pre-Check: CLAUDE.md Size Health*
 - [ ] Are there niche guides in CLAUDE.md used <1x/month? → Move to `docs/guides/`
 - [ ] Is any CLAUDE.md content duplicated across sections? → Consolidate
 - [ ] Are there stale milestone-specific references? → Delete
+- [ ] **Is every rule still TRUE?** Spot-check any rule that cites a specific file, config, or command against the current code. **A wrong rule is worse than a missing one** — it actively sends an agent to do the wrong thing, and burns context on every session doing it. (2026-07-25, chef-chopsky: CLAUDE.md instructed agents to add new specs to Playwright's `testMatch`, but the config had since become a deny-list where specs enroll automatically.) **Delete these outright** and archive to `docs/learnings/resolved-issues.md` noting what replaced them — do not demote to a guide, where the rule stays wrong but gets harder to find.
 - [ ] **Renaming a CLAUDE.md heading? Grep for it first** — `rg -c "<heading text>" docs/ projects/` — other docs cite rules by heading text, and a rename silently breaks them. Prefer broadening the body over retitling.
+
+**Trimming safety**: if the working tree already has unstaged edits to CLAUDE.md, back it up (`cp CLAUDE.md /tmp/claude-md.bak`) before running `git checkout -- CLAUDE.md`. That command restores from the index and silently discards unstaged trims — hit during the 2026-07-25 retro while negative-testing a size check, costing a full redo of four edits.
 
 **When CLAUDE.md is between 32k–40k chars — surface the trim/defer/skip decision explicitly:**
 

--- a/plugins/product-playbook-for-agentic-coding/resources/templates/tasks.md
+++ b/plugins/product-playbook-for-agentic-coding/resources/templates/tasks.md
@@ -81,6 +81,7 @@
 - [ ] **CRITICAL**: ALL acceptance criteria checkboxes above are marked
 - [ ] All dependencies are satisfied
 - [ ] Completion notes added below
+- [ ] **If this task adds a guard** (lint rule, CI job, hook, audit, gate, assertion helper): it was **negative-tested** — run against the broken input it exists to catch, seen to FAIL with an actionable message, then restored. A check only ever observed passing is indistinguishable from a no-op.
 - [ ] **If this task touches instrumentation** (any event, metric, pixel, or telemetry): the CONSUMING query was run and returned a correct non-null value, and its output is pasted in the notes. See the `[INSTRUMENTATION]` task format below — "the event fired" is not acceptance.
 
 **Notes**: [Any relevant notes or blockers]

--- a/plugins/product-playbook-for-agentic-coding/skills/autonomous-execution/SKILL.md
+++ b/plugins/product-playbook-for-agentic-coding/skills/autonomous-execution/SKILL.md
@@ -144,6 +144,25 @@ Two habits that prevent this class:
 
 If no consumer exists yet, the task is not done: write the query.
 
+### Negative-test every guardrail you add (a check that can't fail is not a check)
+
+**Applies to ANY guard, not just instrumentation**: lint rules, CI jobs, pre-commit hooks, schema/migration audits, quality gates, assertion helpers, smoke checks.
+
+Before marking a guard-adding task complete, you must have run it **twice**:
+
+1. **Positive** — against correct input. It passes.
+2. **Negative** — against the broken input it exists to catch. **It fails, with an actionable message that names the fix.**
+
+If you have not seen it fail, you have not tested it — you have only observed that it is silent, and silence is what a no-op looks like too.
+
+Also check the guard can't become **unsatisfiable**. A check that derives its query/config from production code can inherit a filter that removes the very fixture it needs, and then fails forever for a reason unrelated to what it guards. That trains people to ignore it, which is worse than having no guard.
+
+> Real incidents. (a) A metrics verifier inherited the production query's internal-account exclusion — the only attributed fixture was a test account that filter removed, so it failed on production with a message *indistinguishable from the real bug*. (b) An ESLint rule and a CI check were both authored, and only the passing direction was ever exercised; the negative case was assumed.
+>
+> This rule was written down after an earlier incident (a CI guardrail that never fired) and lived **only in a retrospective for two months**, so the next guardrail repeated it. That is why it is here, in the workflow, and not only in a doc.
+
+**Cheap pattern**: temporarily revert the fix (or point the guard at the old/broken version), run the guard, confirm red + read the message, restore. Paste both outcomes as the completion evidence.
+
 ### Acknowledge Method Substitution (don't silently downgrade verification)
 
 If a task names a **specific verification method** (e.g., "browser automation / E2E test of the full flow") and you cannot or do not perform it, you must **say so explicitly** — never substitute a weaker method (a code trace, a line-number citation, a manual read) and report it as if the named method was performed. State: *"The task asked for an E2E run; I did a code trace instead because <reason>. This is weaker — the browser test still needs to run."* For E2E specs specifically, "wired into the test runner's `testMatch`/suite + seen running in CI" is part of done — a spec file that exists but never runs is zero coverage.


### PR DESCRIPTION
Two changes, both from a chef-chopsky retro where **documentation had already failed twice**.

## 1. Negative-test every guardrail — promoted from instrumentation-only

v0.23.0 added *"validate it in BOTH directions"* as an acceptance criterion for **instrumentation** tasks. This promotes it to a general principle covering **any** guard: lint rules, CI jobs, pre-commit hooks, schema/migration audits, quality gates, assertion helpers, smoke checks.

> A guard must be run twice — positive, and against the broken input it exists to catch — and **seen to fail with an actionable message**. A check only ever observed passing is indistinguishable from a no-op.

It also warns about a subtler failure I hit: guards that become **unsatisfiable** by deriving their query from production code and inheriting a filter that removes their own fixture. That fails forever for a reason unrelated to what it guards — which trains people to ignore it, worse than having no guard at all.

**Why this belongs in the workflow, not a doc.** A prior-learnings search found this rule was already established on **2026-05-16** ("negative-testing a CI guardrail is mandatory") and lived **only in a retrospective for two months**. Two more guardrails repeated the mistake since — including one in the very session that produced this PR. The pattern is now at 3 occurrences, so per the skill's own escalation rule it needs a systemic fix rather than a 4th write-up.

Mirrored as a checkbox in `tasks.md` Completion Verification.

## 2. "Is every rule still TRUE?" — new demotion-checklist item

Trimming CLAUDE.md previously looked for *resolved*, *niche*, *duplicated*, or *stale-milestone* content. It never asked whether a rule was still **factually correct**.

Found 2026-07-25: CLAUDE.md instructed agents to add new E2E specs to Playwright's `testMatch` — but the config had since become a **deny-list** where specs enroll automatically. The rule would send an agent hunting for a list that no longer exists, and cost context in every session doing so.

**A wrong rule is worse than a missing one.** Guidance is to *delete* and archive with a note on what replaced it — not demote to a guide, where it stays wrong but gets harder to find.

Plus a **trimming safety note**: back up CLAUDE.md before `git checkout -- CLAUDE.md`. That restores from the index and silently discards unstaged trims — hit during this retro while negative-testing the new size check, costing a full redo of four edits.

## Companion work in the consuming repo

- `scripts/check-claude-md-size.sh` wired into the `code-quality` CI job — converts the "trim if over 40k" retro pre-check into enforcement, since a PR can otherwise push it over silently between retros. **Negative-tested**: warns at current size, exits 1 when padded past the limit.
- The stale `testMatch` rule deleted and archived; CLAUDE.md trimmed 41,539 → 39,989 bytes.

## Validation

`validate-plugin.sh`: 39 commands, 9 agents, 10 skills, 18 templates — **0 errors, 0 warnings**. Version bumped 0.23.3 → **0.24.0** via `sync-version.sh` so `plugin.json` and `marketplace.json` stay in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)