### PR TITLE
fix(learnings): trim to a budget, and check for an existing unmerged fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.24.0"
+      "version": "0.24.1"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-07-26
+
+### Added
+- **`/playbook:learnings` Step A2 — check whether the fix already exists, unmerged, before writing one** — The plugin track never asked this. The "'implemented' means MERGED, not written" rule already covered the codebase, but never pointed at the plugin repo — so a finding whose fix was already sitting in an open PR would get a duplicate written for it. A fix in an unmerged PR still produces the bug in every session, which is exactly why it reached the retrospective. Now greps unmerged branches, open PRs, and uncommitted WIP, and routes on the result: comment on the existing PR with the independent reproduction (a second real occurrence is the strongest argument for merging it) rather than duplicating; open the PR when a fix exists on a branch without one; **surface uncommitted WIP as at-risk, don't commit it** — it's likely another session's in-flight work. Also instructs using `git worktree add` rather than switching branches when the plugin checkout is dirty. Found by running `/playbook:learnings` on a real incident retro that hit two `close.md` bugs already fixed in open PR #61.
+
+### Changed
+- **`/playbook:learnings` CLAUDE.md size gate — trim to a budget, not to the limit** — The retrospective's own promoted content counts against the 40k ceiling, so trimming to 40,000 is trimming to failure; the target is `40,000 − addition − headroom`. Landing at 39,985 (15 chars of headroom) is a failed trim dressed as a pass. Also: re-measure after every edit, and expect condensing rewrites to *increase* size — rewriting a section "tighter" while folding in new content commonly nets positive, so a real trim means deleting or demoting, not rephrasing. Once two consecutive edits stop moving the number, demote a whole section to `docs/guides/` rather than nibbling at prose.
+
+### Fixed
+- **Step A2's own unmerged-fix query was a fatal parse error** — `git log --oneline origin/main..--all` exits with `fatal: bad revision 'origin/main..--all'`, so the check this step exists to perform would never have run. Corrected to `git log --oneline --branches --remotes --not origin/main`, which also avoids bare `--all` dragging in agent-harness checkpoint refs (Conductor writes hundreds per session). Verified by running both forms.
+
 ## [0.24.0] - 2026-07-26
 
 ### Added

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -634,7 +634,10 @@ finding reached this retrospective.
 ```bash
 cd <plugin-repo>
 git fetch -q origin
-git log --oneline origin/main..--all -- <candidate-file>   # fixes on unmerged branches
+# Fixes sitting on unmerged branches. NOTE the ref selection: `origin/main..--all` is a
+# fatal parse error, and bare `--all` drags in agent-harness checkpoint refs (Conductor
+# writes hundreds). `--branches --remotes --not origin/main` is the form that works.
+git log --oneline --branches --remotes --not origin/main -- <candidate-file>
 gh pr list --state open --json number,title,headRefName    # open PRs touching this area
 git status --short                                          # uncommitted WIP in the checkout
 ```

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -90,6 +90,18 @@ If `/playbook:learnings` was invoked from `/playbook:close`, the close skill's P
    Trim first, then continue the retrospective? Or surface specific candidates?
    ```
 
+   **Trim to a budget, not to the limit.** The content this retrospective promotes *also*
+   counts against the 40k ceiling, so the target is `40,000 − (planned addition) − headroom`,
+   not `40,000`. Estimate the addition first (a substantive new rule runs 600–900 chars), then
+   trim to that number. Landing at 39,985 with 15 chars of headroom is a failed trim — the next
+   session's first edit breaks the limit again.
+
+   **Re-measure after every edit** (`wc -c CLAUDE.md`), and expect condensing rewrites to
+   *increase* size. Rewriting a section to be "tighter" while folding in new content commonly
+   nets positive; a real trim means deleting or demoting, not rephrasing. If two consecutive
+   edits haven't moved the number meaningfully, stop nibbling at prose and demote a whole
+   section to `docs/guides/` with a one-line reference — that is the only reliably large win.
+
 3. **If between 32,000 and 40,000 chars** (80% of limit): flag as approaching threshold but don't block. Note it in the prior-learnings summary so the user can choose to trim opportunistically during Step 6 (Promotion).
 
 **Why pre-flight, not just pre-promotion**: catching size violations before any other work means the user can decide to trim *first* and have a clean baseline. Discovering it mid-promotion (which is where the historical check lived) forces a context-switch when the retrospective should be wrapping up. The Step 6 health check remains as a backstop in case content is added during facilitation.
@@ -608,6 +620,34 @@ For each finding tagged `plugin` or `both`:
 1. Check CLAUDE.md or MEMORY.md for the plugin repo path
 2. If not found, search: `find ~ -maxdepth 4 -name "product-playbook-for-agentic-coding" -type d 2>/dev/null`
 3. Cache the discovered path in MEMORY.md for future sessions
+
+**Step A2 — Check whether the fix already exists but never merged (do this BEFORE writing one):**
+
+The "'implemented' means MERGED, not written" rule from the prior-learnings pre-check applies to
+the *plugin* too, and it is easy to miss because the plugin repo is not the one you're working in.
+A fix sitting in an open PR still produces the bug in every session — which is precisely why the
+finding reached this retrospective.
+
+```bash
+cd <plugin-repo>
+git fetch -q origin
+git log --oneline origin/main..--all -- <candidate-file>   # fixes on unmerged branches
+gh pr list --state open --json number,title,headRefName    # open PRs touching this area
+git status --short                                          # uncommitted WIP in the checkout
+```
+
+Route on what you find:
+- **Open PR already fixes it** → do NOT write a duplicate. Comment on that PR with this
+  session's independent reproduction (a second real occurrence is the strongest possible
+  argument for merging it) and report the PR to the user as the action item.
+- **Fixed on an unmerged/unpushed branch with no PR** → open the PR; that is the missing step.
+- **Uncommitted WIP in the plugin checkout** → surface it, don't commit it — it is likely
+  another session's in-flight work. Note it as at-risk.
+- **Nothing exists** → proceed to Step B.
+
+**If the plugin checkout is dirty, use a worktree rather than switching branches** —
+`git worktree add -b <branch> /tmp/<name> origin/main` — so your edits can't entangle with or
+clobber the in-flight work. Verify with `git -C <plugin-repo> status --short` afterward.
 
 **Step B — Map findings to skills/commands:**
 


### PR DESCRIPTION
Two gaps found by *running* `/playbook:learnings` on a real incident retrospective (chef-chopsky — production OpenAI quota outage, 2026-07-26). Both cost real time in that session.

## 1. The CLAUDE.md gate says trimming is mandatory, but not what to trim *to*

The retrospective's own promoted content counts against the 40k ceiling, so trimming to 40,000 is trimming to failure. This run landed at **39,985 — 15 chars of headroom**, which is a failed trim dressed as a pass.

It also took **8 sequential edits**, because the first "trim" was a condensing rewrite that *added* 178 chars. That's the non-obvious part worth encoding: rewriting a section to be tighter while folding in new content commonly nets positive. Only deleting or demoting reliably shrinks.

Now instructs: budget `40,000 − addition − headroom`, re-measure after every edit, and once two edits stop moving the number, demote a whole section to `docs/guides/` instead of nibbling at prose.

## 2. The plugin track never checked whether the fix already exists, unmerged

This session hit two `close.md` bugs — a checkpoint clobber (overwrote another workspace's handoff) and a directory-level `check-ignore` that made `git add` exit non-zero and silently skip a commit. **Both were already fixed in open PR #61.**

Without this check the natural move is to write a duplicate fix. The correct action item was "merge #61" — a fix in an open PR still produces the bug in every session, which is exactly why it reached the retrospective at all. The plugin's own prior-learnings rule (*"'implemented' means MERGED, not written"*) already covers this for the codebase; it simply never pointed at the plugin repo.

Adds a `Step A2` that greps for unmerged fixes and open PRs before writing anything, and routes on the result (comment on the existing PR with the independent reproduction rather than duplicating it).

Also adds the **worktree** instruction: that plugin checkout had uncommitted WIP on `close.md`, so switching branches to make these very edits would have risked entangling someone else's in-flight work. These edits were made in `git worktree add -b … origin/main` and the dirty checkout verified untouched.

## Evidence

- Corroboration posted to #61: https://github.com/daviswhitehead/product-playbook-for-agentic-coding-plugin/pull/61#issuecomment-5081697361
- Source retro: `docs/learnings/2026-07-05-gate-metric-zero-means-broken-not-passing.md` (third-incident addendum) in daviswhitehead/chef-chopsky#444

🤖 Generated with [Claude Code](https://claude.com/claude-code)