### PR TITLE
improve(learnings): lower CLAUDE.md size thresholds to match published best practice

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.24.2"
+      "version": "0.24.3"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.3] - 2026-07-26
+
+### Changed
+- **CLAUDE.md size thresholds lowered to match published guidance, and a line check added** (`/playbook:learnings` pre-check + Step 6 backstop, `learning-capture` skill) — was 32,000 / 40,000 chars with no line check; now **16,000 chars or 200 lines** (soft) and **24,000 chars or 300 lines** (hard, mandatory trim), whichever trips first.
+
+  **Lines are the cited number; the char figures are an explicitly derived companion.** Anthropic's docs state: *"target under 200 lines per CLAUDE.md file. Longer files consume more context and reduce adherence."* HumanLayer treats 300 lines as a hard ceiling (their own root CLAUDE.md is under 60). The char figures assume ~80 chars/line, which holds for prose-heavy files and is far off for terse bullet lists — this plugin's own CLAUDE.md averages ~32 chars/line, so its line count binds long before its char count. The doc now says so plainly rather than presenting both as equally sourced.
+
+  The two thresholds measure different failure modes and both are kept deliberately: lines ≈ instruction count (adherence), chars ≈ context cost. Frontier models follow roughly 150–200 instructions consistently and Claude Code's own system prompt already occupies ~50 of those slots, so instruction count is usually the binding constraint — which is why the old char-only check could pass a file already carrying several times the targeted instruction count.
+
+- **Promotions past the soft limit follow "one in, one out"** — each new CLAUDE.md rule names a demotion or deletion candidate in the same edit.
+
+**Note for existing projects**: this materially tightens the gate. A CLAUDE.md near the old 40,000-char ceiling is roughly 16,000 over the new hard limit, so the next `/playbook:learnings` run in such a repo will require trimming before it can promote anything. That forcing function is the intent, but it lands immediately.
+
 ## [0.24.2] - 2026-07-26
 
 ### Fixed

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -76,7 +76,15 @@ If `/playbook:learnings` was invoked from `/playbook:close`, the close skill's P
 
 1. Run `wc -c -l CLAUDE.md` (skip if no CLAUDE.md exists in the project).
 
-   **Thresholds** (revised 2026-07-26; the old 32k/40k numbers were ~3x published best practice — a file "passed" the check while already being 2.8x Anthropic's guidance): official Anthropic docs target **under 200 lines** ("longer files consume more context and reduce adherence"); community consensus (HumanLayer, Builder.io) puts the ceiling at ~300 lines. The binding constraint is the model's instruction-following budget, not tokens — every low-value line taxes compliance with the critical rules.
+   **Thresholds** (revised 2026-07-26). **Lines are the published number; the char figures are a derived companion.**
+
+   - **Lines — cited.** Anthropic's docs: *"target under 200 lines per CLAUDE.md file. Longer files consume more context and reduce adherence."* HumanLayer treats **300 lines as a hard ceiling** (their own root CLAUDE.md is under 60). Hence 200 soft / 300 hard.
+   - **Chars — derived, not published.** 16,000 / 24,000 assume ~80 chars per line. That holds for prose-heavy files and is *far* off for terse bullet lists — this plugin's own CLAUDE.md averages ~32 chars/line, so its line count binds long before its char count. Treat the char figures as a secondary guard, not an independent standard.
+   - **Whichever trips first wins**, because the two measure different failure modes: lines ≈ instruction count (adherence), chars ≈ context cost. A file can blow one while comfortably passing the other.
+
+   The binding constraint is usually the model's instruction-following budget, not tokens: frontier models follow roughly 150–200 instructions consistently, and Claude Code's own system prompt already occupies ~50 of those slots. Every low-value line taxes compliance with the critical rules.
+
+   *Prior thresholds were 32,000 / 40,000 chars with no line check at all — so a file could pass while carrying several times the instruction count the published guidance targets.*
 
 2. **If over 24,000 chars or 300 lines**: trimming is **mandatory** before this retrospective adds any new content. Past this point, CLAUDE.md degrades agent performance. Surface to the user immediately:
 
@@ -564,7 +572,7 @@ The primary CLAUDE.md size check now runs in **Pre-Check: CLAUDE.md Size Health*
 - Condense verbose sections to a reference + link
 
 **Demotion checklist** (run before promotion):
-- [ ] **Does a CLAUDE.md block restate a `docs/solutions/` or `docs/guides/` doc that already exists? → Condense to a one-line pointer.** Try this first: it deletes duplication rather than knowledge, so nothing is lost and it usually frees enough budget to land the new rule in the same edit. (2026-07-25, chef-chopsky: CLAUDE.md sat at 39,948 of 40,000 chars. Condensing a four-bullet PostHog block that restated two existing solution docs freed ~750 chars and made adding a new CRITICAL rule a net **+22**. The trim/defer/skip decision below never had to be surfaced.)
+- [ ] **Does a CLAUDE.md block restate a `docs/solutions/` or `docs/guides/` doc that already exists? → Condense to a one-line pointer.** Try this first: it deletes duplication rather than knowledge, so nothing is lost and it usually frees enough budget to land the new rule in the same edit. (2026-07-25, chef-chopsky: CLAUDE.md sat at 39,948 chars against the 40,000 ceiling in force at the time — well over today's 24,000. Condensing a four-bullet PostHog block that restated two existing solution docs freed ~750 chars and made adding a new CRITICAL rule a net **+22**. The trim/defer/skip decision below never had to be surfaced.)
 - [ ] Are there RESOLVED known issues still in CLAUDE.md? → Archive
 - [ ] Are there niche guides in CLAUDE.md used <1x/month? → Move to `docs/guides/`
 - [ ] Is any CLAUDE.md content duplicated across sections? → Consolidate

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -74,11 +74,14 @@ If `/playbook:learnings` was invoked from `/playbook:close`, the close skill's P
 
 **Run this check at the very start**, alongside the prior learnings search. CLAUDE.md is loaded into every agent session, so size growth has compounding cost.
 
-1. Run `wc -c CLAUDE.md` (skip if no CLAUDE.md exists in the project).
-2. **If over 40,000 chars**: trimming is **mandatory** before this retrospective adds any new content. Past this point, CLAUDE.md degrades agent performance. Surface to the user immediately:
+1. Run `wc -c -l CLAUDE.md` (skip if no CLAUDE.md exists in the project).
+
+   **Thresholds** (revised 2026-07-26; the old 32k/40k numbers were ~3x published best practice — a file "passed" the check while already being 2.8x Anthropic's guidance): official Anthropic docs target **under 200 lines** ("longer files consume more context and reduce adherence"); community consensus (HumanLayer, Builder.io) puts the ceiling at ~300 lines. The binding constraint is the model's instruction-following budget, not tokens — every low-value line taxes compliance with the critical rules.
+
+2. **If over 24,000 chars or 300 lines**: trimming is **mandatory** before this retrospective adds any new content. Past this point, CLAUDE.md degrades agent performance. Surface to the user immediately:
 
    ```
-   CLAUDE.md is at <N> chars — over the 40,000 hard limit.
+   CLAUDE.md is at <N> chars / <L> lines — over the hard limit (24,000 chars / 300 lines).
    Trimming is required before this retrospective can promote new content.
 
    Common demotion candidates:
@@ -91,9 +94,9 @@ If `/playbook:learnings` was invoked from `/playbook:close`, the close skill's P
    ```
 
    **Trim to a budget, not to the limit.** The content this retrospective promotes *also*
-   counts against the 40k ceiling, so the target is `40,000 − (planned addition) − headroom`,
-   not `40,000`. Estimate the addition first (a substantive new rule runs 600–900 chars), then
-   trim to that number. Landing at 39,985 with 15 chars of headroom is a failed trim — the next
+   counts against the ceiling, so the target is `24,000 − (planned addition) − headroom`,
+   not `24,000`. Estimate the addition first (a substantive new rule runs 600–900 chars), then
+   trim to that number. Landing 15 chars under the limit is a failed trim — the next
    session's first edit breaks the limit again.
 
    **Re-measure after every edit** (`wc -c CLAUDE.md`), and expect condensing rewrites to
@@ -102,7 +105,7 @@ If `/playbook:learnings` was invoked from `/playbook:close`, the close skill's P
    edits haven't moved the number meaningfully, stop nibbling at prose and demote a whole
    section to `docs/guides/` with a one-line reference — that is the only reliably large win.
 
-3. **If between 32,000 and 40,000 chars** (80% of limit): flag as approaching threshold but don't block. Note it in the prior-learnings summary so the user can choose to trim opportunistically during Step 6 (Promotion).
+3. **If between 16,000 and 24,000 chars (or 200–300 lines)**: flag as approaching threshold but don't block. Note it in the prior-learnings summary so the user can choose to trim opportunistically during Step 6 (Promotion). Over the soft limit, promotions should follow **one in, one out**: each new CLAUDE.md rule names a demotion/deletion candidate in the same edit.
 
 **Why pre-flight, not just pre-promotion**: catching size violations before any other work means the user can decide to trim *first* and have a clean baseline. Discovering it mid-promotion (which is where the historical check lived) forces a context-switch when the retrospective should be wrapping up. The Step 6 health check remains as a backstop in case content is added during facilitation.
 
@@ -554,7 +557,7 @@ A learning left in a doc is a learning that will be re-learned the hard way. Pro
 
 #### Pre-Promotion: CLAUDE.md Health Check (Backstop)
 
-The primary CLAUDE.md size check now runs in **Pre-Check: CLAUDE.md Size Health** at the start of the workflow. This step is a backstop in case content was added during Step 3 facilitation (e.g., new gotchas discovered mid-retrospective). Re-run `wc -c CLAUDE.md`; if it's grown past 40k since pre-flight, apply the same demotion guidance:
+The primary CLAUDE.md size check now runs in **Pre-Check: CLAUDE.md Size Health** at the start of the workflow. This step is a backstop in case content was added during Step 3 facilitation (e.g., new gotchas discovered mid-retrospective). Re-run `wc -c -l CLAUDE.md`; if it's grown past 24k chars / 300 lines since pre-flight, apply the same demotion guidance:
 - Archive RESOLVED known issues → `docs/learnings/resolved-issues.md`
 - Move niche/domain-specific guides → `docs/guides/[topic].md` (keep 1-line reference)
 - Remove content that duplicates the Quick Reference section
@@ -571,12 +574,12 @@ The primary CLAUDE.md size check now runs in **Pre-Check: CLAUDE.md Size Health*
 
 **Trimming safety**: if the working tree already has unstaged edits to CLAUDE.md, back it up (`cp CLAUDE.md /tmp/claude-md.bak`) before running `git checkout -- CLAUDE.md`. That command restores from the index and silently discards unstaged trims — hit during the 2026-07-25 retro while negative-testing a size check, costing a full redo of four edits.
 
-**When CLAUDE.md is between 32k–40k chars — surface the trim/defer/skip decision explicitly:**
+**When CLAUDE.md is between 16k–24k chars (or 200–300 lines) — surface the trim/defer/skip decision explicitly:**
 
 Don't silently choose between trimming and skipping the CLAUDE.md addition. Surface the three options to the user with a recommendation:
 
 ```
-CLAUDE.md is currently at <N> chars (over the 32k soft limit, under the 40k hard limit).
+CLAUDE.md is currently at <N> chars / <L> lines (over the 16k-char/200-line soft limit, under the 24k-char/300-line hard limit).
 
 I have three options for this finding:
 1. **Trim first** — apply the demotion checklist above, then add the new content (estimated ~10 min of doc surgery)

--- a/plugins/product-playbook-for-agentic-coding/skills/learning-capture/SKILL.md
+++ b/plugins/product-playbook-for-agentic-coding/skills/learning-capture/SKILL.md
@@ -150,8 +150,8 @@ When performing a deep retrospective (analyzing SpecStory session files in `.spe
 **Improvement**: If unintentional, add scope-check trigger to MEMORY.md.
 
 ### Pattern: CLAUDE.md Growth
-**Signal**: CLAUDE.md size exceeds 32,000 chars or triggers the performance warning (>40k).
-**How to detect**: Run `wc -c CLAUDE.md`. Check for RESOLVED issues still inline, niche guides that belong in `docs/guides/`, duplicate content (e.g., test commands listed in both Quick Reference and a Common Workflows section).
+**Signal**: CLAUDE.md exceeds 16,000 chars / 200 lines (soft) or 24,000 chars / 300 lines (hard — mandatory trim). Anthropic's official guidance targets under 200 lines; adherence degrades as instruction count grows.
+**How to detect**: Run `wc -c -l CLAUDE.md`. Check for RESOLVED issues still inline, niche guides that belong in `docs/guides/`, duplicate content (e.g., test commands listed in both Quick Reference and a Common Workflows section).
 **Root cause**: The learnings promotion workflow is additive-only — it promotes content UP to CLAUDE.md but never demotes stale content DOWN to docs/guides/ or docs/learnings/.
 **Improvement**: Before promoting new learnings to CLAUDE.md, check size and archive stale content. Resolved issues should be moved to `docs/learnings/resolved-issues.md`. Niche guides should be moved to `docs/guides/` with a 1-line reference in CLAUDE.md.
 
@@ -257,13 +257,13 @@ If session history files are available (`.specstory/history/*.md`):
 ### Step 6: CLAUDE.md Health Check & Promote Key Learnings
 
 **Before promoting**, check CLAUDE.md health:
-1. Run `wc -c CLAUDE.md` to check current size
-2. If over 32,000 chars (80% of 40k limit), trigger a **trimming pass** before adding content:
+1. Run `wc -c -l CLAUDE.md` to check current size
+2. If over 16,000 chars or 200 lines, trigger a **trimming pass** before adding content, and follow **one in, one out** (each promotion names a demotion candidate):
    - Archive RESOLVED known issues to `docs/learnings/resolved-issues.md`
    - Move niche/domain-specific guides to `docs/guides/`
    - Remove content that duplicates the Quick Reference section
    - Condense verbose sections that can be replaced with a 1-line reference + link
-3. If over 40,000 chars, trimming is **mandatory** before any promotion
+3. If over 24,000 chars or 300 lines, trimming is **mandatory** before any promotion
 
 **Promotion hierarchy** (highest = most actionable):
 - **Code/scripts** (automatic) > **CLAUDE.md** (always visible) > **Templates** (on-demand) > **Docs** (reference)


### PR DESCRIPTION
## Summary
- Lower the CLAUDE.md health-check thresholds in `/playbook:learnings` and the `learning-capture` skill: soft trigger 32k → **16k chars or 200 lines**, hard limit 40k → **24k chars or 300 lines**
- Check line count as well as chars (`wc -c -l`)
- Add **one in, one out** rule: over the soft limit, each promotion to CLAUDE.md names a demotion candidate in the same edit
- Cite the research basis inline (Anthropic memory docs: <200 lines; HumanLayer/Builder.io: ≤300 lines; instruction-following budget is the binding constraint)

## Why
The old thresholds let chef-chopsky's CLAUDE.md grow to 41.5k chars / 563 lines — 2.8x Anthropic's guidance — while the health check stayed quiet until the very end. The additive-only failure mode the skill itself documents ('promotes UP, never demotes DOWN') needs thresholds that fire early enough for one-in-one-out to keep equilibrium.

Historical references (design-history doc, dated retro examples) intentionally left at old numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)