### PR TITLE
fix(close): step 4's archive-detection check never actually ran

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.24.1"
+      "version": "0.24.2"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.2] - 2026-07-26
+
+### Fixed
+- **`/playbook:close` step 4 — the archive-detection check never actually ran** — The one-liner shipped in 0.23.5 interpolated the checkpoint's `**Branch**:` line straight into `grep` as a *regex*. A leading `**` is an invalid repetition operator, so BSD `grep` (the macOS default) aborts with `repetition-operator operand invalid` on **every** invocation — the check that exists to stop another workspace's handoff being overwritten has never once detected an archive. Replaced with a tri-state block printing exactly one of `NO_EXISTING_CHECKPOINT` / `ALREADY_ARCHIVED` / `ARCHIVE_REQUIRED`, using `grep -rlF --` (literal compare, and `--` guards a pattern starting with `-`) and matching the `**Branch**:` line by pattern instead of a hardcoded `sed -n '3p'`.
+
+  Two further defects in the same one-liner, both now closed:
+  - **Empty output was overloaded three ways** — "no `latest.md` at all", "exists but unarchived", and "the command errored" were indistinguishable, and the doc read all three as "rename it first". On a first-ever close-out that means `git mv` on a nonexistent file (`fatal: bad source`, exit 128).
+  - **A blank line 3 produced an empty grep pattern, which matches every file** — reported as "already archived" and green-lit overwriting an irreplaceable handoff. This is the data-loss path the step was written to prevent, reachable whenever the checkpoint's line 3 happens to be blank.
+
+  **Negative-tested in both directions** against four fixtures (no `latest.md`; unarchived; already archived; blank line 3 alongside an unrelated archive). The old form is wrong in all four — silent, fatal-erroring, fatal-erroring, and falsely "already archived" respectively; the new form returns the correct state in all four. Per the "negative-test every guardrail" rule added in 0.24.0.
+- **Step 6 stages an explicit file list, never the directory** — `git add -f docs/checkpoints/` force-commits everything the repo deliberately ignored (other workspaces' checkpoints, local scratch state) under a "session checkpoint" label — step 4's clobbering failure in the opposite direction. Now uses a `CKPT_FILES` array that also carries any archive step 4 created, so the file just rescued doesn't stay untracked under an ignored path. Force-adding overrides a deliberate repo decision, so the step now says to **ask** rather than defaulting to it.
+- **`git mv` caveat** — plain `mv` when the checkpoint isn't tracked, which is the common case under a gitignored path; `git mv` on an untracked file fails with "bad source".
+
 ## [0.24.1] - 2026-07-26
 
 ### Added

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
@@ -76,16 +76,48 @@ You are facilitating an end-of-session close-out. Run each phase in order. Skip 
 
    ```bash
    # Is there an existing checkpoint, and is its content archived anywhere else?
-   test -s docs/checkpoints/latest.md && \
-     grep -rl "$(sed -n '3p' docs/checkpoints/latest.md)" docs/checkpoints/ | grep -v latest.md
+   # Prints exactly one of: NO_EXISTING_CHECKPOINT | ALREADY_ARCHIVED | ARCHIVE_REQUIRED
+   if [ ! -s docs/checkpoints/latest.md ]; then
+     echo "NO_EXISTING_CHECKPOINT"
+   else
+     branch_line=$(sed -n '/^\*\*Branch\*\*:/p' docs/checkpoints/latest.md | head -1)
+     if [ -z "$branch_line" ]; then
+       echo "ARCHIVE_REQUIRED"   # can't identify it -> never assume it's safe to clobber
+     elif grep -rlF -- "$branch_line" docs/checkpoints/ \
+            | grep -qv '^docs/checkpoints/latest\.md$'; then
+       echo "ALREADY_ARCHIVED"
+     else
+       echo "ARCHIVE_REQUIRED"
+     fi
+   fi
    ```
 
-   If no archived copy comes back, rename it first — do NOT overwrite:
+   - `NO_EXISTING_CHECKPOINT` → nothing to archive; go straight to step 5.
+   - `ALREADY_ARCHIVED` → safe to overwrite in step 5.
+   - `ARCHIVE_REQUIRED` → rename it first, do NOT overwrite:
 
    ```bash
    git mv docs/checkpoints/latest.md docs/checkpoints/<YYYY-MM-DD>-<topic-from-its-title>.md
-   # (plain `mv` if it isn't tracked)
+   # (plain `mv` if it isn't tracked — which is the common case when the path is
+   #  gitignored; see step 6. `git mv` on an untracked file fails with "bad source".)
    ```
+
+   Three things this shape fixes, all of which broke the earlier one-liner:
+
+   - **The branch line was interpolated into `grep` as a regex.** `**Branch**: <name>`
+     starts with `**`, an invalid repetition operator — BSD `grep` (macOS default) and
+     `ugrep` both abort with `repetition-operator operand invalid` / `empty (sub)expression`
+     on *every* run, so the check never actually detected an archive. `-F` compares the
+     literal string; `--` guards a pattern that starts with `-`.
+   - **Empty/absent output was overloaded three ways** — "no `latest.md` at all", "exists
+     but unarchived", and "the command errored" were indistinguishable, and the doc read all
+     of them as "rename it first". On a first-ever close-out that means `git mv` on a
+     nonexistent file (`fatal: bad source`, exit 128). Worse, a `latest.md` whose branch
+     line was missing produced an *empty* grep pattern, which matches every file — reported
+     as "already archived" and green-lit the overwrite. Each state now names itself.
+   - **`sed -n '3p'` hardcoded the line number**, and `grep -v latest.md` was an unanchored
+     regex (`.` matches any character). Match the `**Branch**:` line by pattern and exclude
+     the file by exact path.
 
    Read the file's own `**Branch**:` line to name the archive — it usually identifies the
    workspace and topic. Only skip archiving if the existing checkpoint is demonstrably yours
@@ -132,38 +164,50 @@ You are facilitating an end-of-session close-out. Run each phase in order. Skip 
    ```bash
    git branch --show-current   # still the branch Phase 1 validated?
 
+   # Stage ONLY the files this session wrote. Never `git add` the directory.
+   CKPT_FILES=(docs/checkpoints/latest.md)
+   # If step 4 archived a prior checkpoint, it MUST go in this list too — otherwise the
+   # file you just rescued stays untracked under an ignored path, i.e. still expendable.
+   CKPT_FILES+=(docs/checkpoints/<YYYY-MM-DD>-<topic>.md)   # omit if step 4 archived nothing
+
    # NOTE: check-ignore must test the FILE, not the directory. A `docs/checkpoints/`
    # pattern does NOT make `git check-ignore -q docs/checkpoints/` return true, even
    # though `git add` on that directory refuses. Testing the dir silently picks the
    # wrong branch here.
-   #
-   # Force-add the EXPLICIT files this session wrote, never the directory: `git add -f`
-   # on `docs/checkpoints/` commits everything the repo deliberately ignored — other
-   # workspaces' checkpoints, local scratch state — under a "session checkpoint" label.
-   # That is step 4's clobbering failure in the opposite direction. If step 4 archived a
-   # prior checkpoint, add that file here too, or the file you just rescued stays
-   # untracked under an ignored path (i.e. still expendable).
    if git check-ignore -q docs/checkpoints/latest.md; then
-     git add -f -- docs/checkpoints/latest.md    # plus any archive step 4 created
+     # The repo ignores this path on purpose. ASK before overriding that, then:
+     git add -f -- "${CKPT_FILES[@]}"
    else
-     git add -- docs/checkpoints/latest.md       # plus any archive step 4 created
+     git add -- "${CKPT_FILES[@]}"
    fi
    git commit -m "chore: session checkpoint"
    ```
 
-   Two failure modes this closes, both hit in a real run (chef-chopsky, 2026-07-25):
+   Three failure modes this closes, the first two hit in a real run (chef-chopsky,
+   2026-07-25):
 
-   - **`docs/checkpoints/` is frequently gitignored** ("local resume state"). `git add`
-     then silently stages *nothing*, `git commit` reports nothing to commit, and the
-     close-out reports success while the handoff exists only as an untracked file. Git
+   - **`docs/checkpoints/` is frequently gitignored** ("local resume state"). A plain
+     `git add` then silently stages *nothing*, `git commit` reports nothing to commit, and
+     the close-out reports success while the handoff exists only as an untracked file. Git
      treats ignored files as expendable, so **the next `git checkout` overwrites it without
      warning** — the checkpoint is gone with no reflog entry, because it was never an
-     object. If a repo deliberately keeps checkpoints local, that is a decision to make
-     explicitly and state in the summary — not one to arrive at by a silent no-op.
+     object.
    - **The branch can change between Phase 1 and here.** Phase 1's check is a point-in-time
      read; in a shared workspace another agent can switch branches while you are waiting on
      tools. Re-read it immediately before committing, and if it moved, re-run the Phase 1
      branch decision rather than committing to whatever branch you happen to be on.
+   - **`git add -f` on the *directory* commits everything the repo deliberately ignored** —
+     every other workspace's `latest.md` archive, scratch files, local resume state — and
+     buries them in a commit labelled "session checkpoint". That is the same
+     other-agent-clobbering failure step 4 exists to prevent, in the opposite direction.
+     Force-add the explicit file list, never the directory.
+
+   When the path is gitignored, force-adding overrides a deliberate repo decision, so
+   **ask** rather than defaulting. If the user wants checkpoints to stay local, skip the
+   commit and say so explicitly in the Phase 5 summary ("left local — path is gitignored")
+   along with the fact that a `git checkout` can delete it. A repo keeping checkpoints local
+   is a fine choice to make on purpose — just not one to arrive at by a silent no-op, and
+   not one to silently overrule either.
 
 ## Phase 4: Learn Flow
 


### PR DESCRIPTION
Rescues uncommitted work that was stranded in a dormant checkout at `~/GitHub/product-playbook-for-agentic-coding-plugin` (surfaced as a deferral on #61), rebased onto current main and verified.

## The bug

0.23.5 added step 4 to stop `/playbook:close` from overwriting another workspace's handoff. Its detection one-liner interpolated the checkpoint's `**Branch**:` line straight into `grep` as a **regex**:

```bash
grep -rl "$(sed -n '3p' docs/checkpoints/latest.md)" docs/checkpoints/ | grep -v latest.md
```

A leading `**` is an invalid repetition operator, so BSD `grep` — the macOS default — aborts on **every** invocation:

```
grep: repetition-operator operand invalid
```

The check has never once detected an archive. It fails safe in the common case (always "archive first"), but two paths are worse than that.

## Two further defects, same one-liner

1. **Empty output was overloaded three ways** — "no `latest.md`", "exists but unarchived", and "the command errored" are indistinguishable, and the doc read all three as "rename it first". On a first-ever close-out that's `git mv` on a nonexistent file → `fatal: bad source`, exit 128.

2. **A blank line 3 produces an empty grep pattern, which matches every file** → reported as "already archived" → green-lights the overwrite. This is the exact data-loss the step was written to prevent, and it's reachable whenever line 3 happens to be blank:

```
line 3 of latest.md: []
OLD verdict: docs/checkpoints/2026-01-01-unrelated.md
^^ non-empty => doc reads this as ALREADY ARCHIVED => overwrite => handoff destroyed
```

## The fix

A tri-state block printing exactly one of `NO_EXISTING_CHECKPOINT` / `ALREADY_ARCHIVED` / `ARCHIVE_REQUIRED`, with each state named so none can be inferred from silence. `grep -rlF --` compares literally (and `--` guards a pattern starting with `-`); the `**Branch**:` line is matched by pattern rather than a hardcoded `sed -n '3p'`; the exclusion is anchored to an exact path instead of the unanchored regex `latest.md`.

Step 6 also now stages an explicit `CKPT_FILES` list — **including any archive step 4 just created**, otherwise the file you rescued stays untracked under an ignored path, i.e. still expendable. `git add -f` on the *directory* commits everything the repo deliberately ignored (other workspaces' checkpoints, local scratch) under a "session checkpoint" label — step 4's clobbering failure in the opposite direction. And since force-adding overrides a deliberate repo decision, the step now says to **ask** rather than defaulting to it.

## Negative-tested in both directions

Per the "negative-test every guardrail" rule added in 0.24.0 — this is a guard, so it was run against the broken inputs it exists to catch, not just the happy path.

| Fixture | Old | New |
|---|---|---|
| No `latest.md` (first-ever close-out) | silent — indistinguishable from "unarchived" | `NO_EXISTING_CHECKPOINT` |
| Unarchived checkpoint | `grep: repetition-operator operand invalid` | `ARCHIVE_REQUIRED` |
| Already archived | `grep: repetition-operator operand invalid` — never detects it | `ALREADY_ARCHIVED` |
| Blank line 3 + unrelated archive | falsely "already archived" → **handoff destroyed** | `ARCHIVE_REQUIRED` |

Old form wrong in all four; new form correct in all four.

## Validation

`scripts/validate-plugin.sh`: 39 commands, 9 agents, 10 skills, 18 templates — 0 errors, 0 warnings. `check-version-bump.sh`: 0.24.1 → **0.24.2**.

## Provenance

This content originated as uncommitted WIP in a dormant checkout whose HEAD still sat at the pre-merge #61 tip. It was extracted read-only, rebased onto main, and the one conflict — against the narrowing I applied while merging #61 — resolved toward this version, which is strictly better (the `CKPT_FILES` array actually carries the archive file, where my merge-time note only mentioned it in a comment). The source checkout was not modified; it still holds the same uncommitted diff and can be discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)