### PR TITLE
fix(monitor-pr): --delete-branch half-fail leaves the remote branch alive

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.24.3"
+      "version": "0.24.4"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.4] - 2026-07-26
+
+### Fixed
+- **`/playbook:monitor-pr` Step 4 stated a false fact about `gh pr merge --delete-branch`** — The note claimed that when another worktree holds the PR branch, the local-delete failure is "harmless (the remote branch is still deleted)". It is not: the operation deletes **neither** branch, ending with the remote branch alive. Because the PR *is* merged, the error reads as cosmetic and gets walked past.
+
+  The wrong version was load-bearing — it explicitly told you the check was unnecessary, so the surviving branch was never noticed. A missing rule would have left normal curiosity intact. This is the "Is every rule still TRUE?" check added in 0.24.0 landing on the playbook's own documentation.
+
+  **Verified in both directions in one session** (gh 2.88.0): 6 merges where `--delete-branch` succeeded left 0 remote branches; all 3 merges that hit the worktree error left the remote branch alive, each needing a manual `git push origin --delete`. Confirmed with `git ls-remote --heads` after `git fetch --prune`, not the local `git branch -r` cache.
+
+  Step 4 now carries the corrected behavior, a verification snippet, and the repo-level fix that makes the failure mode moot: `delete_branch_on_merge: true` ("Automatically delete head branches") deletes the head branch on every merge, including web-UI merges. An audit of this repo — which has the setting `false` — found 24 stale remote branches from merged PRs going back to 2026-04, though most stem from merges that never passed `--delete-branch` at all rather than from the gh bug itself.
+
+### Changed
+- **`docs/learnings/2026-07-17-merging-stacked-prs-across-worktrees.md`** — dated second-incident addendum correcting Learning #3 (the origin of the false claim), with the evidence table, both root causes separated, and the systemic repo-level fix.
+
 ## [0.24.3] - 2026-07-26
 
 ### Changed

--- a/docs/learnings/2026-07-17-merging-stacked-prs-across-worktrees.md
+++ b/docs/learnings/2026-07-17-merging-stacked-prs-across-worktrees.md
@@ -40,10 +40,14 @@ to `/playbook:monitor-pr` Step 3.
 
 ### 3. `gh pr merge --delete-branch` silently switches your checkout
 
+> ⚠️ **The second sentence below is WRONG — corrected 2026-07-26.** The remote branch is
+> **not** deleted when the local delete fails; neither branch is. Text kept as written for
+> the historical record. See the [2026-07-26 addendum](#2026-07-26-second-incident-addendum--learning-3-was-factually-wrong).
+
 After deleting the PR branch it checks out the default branch and pulls — in a
 parallel-agent workspace this strands the session on `main` without warning. Re-checkout
-your working branch after merging. If another worktree holds the branch, the local delete
-fails harmlessly (remote still deleted), leaving that checkout on a remote-less branch.
+your working branch after merging. ~~If another worktree holds the branch, the local delete
+fails harmlessly (remote still deleted), leaving that checkout on a remote-less branch.~~
 Promoted to `/playbook:monitor-pr` Step 4.
 
 ### Bonus observation
@@ -58,3 +62,70 @@ before assuming the branch is gone.
 - [x] CLAUDE.md: "Merging multiple open PRs (stacked bumps)" section
 - [x] `/playbook:monitor-pr`: worktree-held-branch pattern (Step 3) + post-merge local-state note (Step 4)
 - [x] Session memory: worktree pattern cached for future sessions
+
+---
+
+## 2026-07-26 second-incident addendum — Learning #3 was factually wrong
+
+The same scenario recurred: a second merge-all-open-PRs session (9 PRs, #57–#67,
+0.23.0 → 0.24.3) across the same shared worktrees. Learnings #1 and #2 held up
+perfectly and made the session routine. **Learning #3 did not — half of it is false**,
+and it had already been promoted into `/playbook:monitor-pr` Step 4, so the error
+shipped to every install.
+
+### The false claim
+
+> "If another worktree holds the branch, the local delete fails harmlessly
+> (remote still deleted), leaving that checkout on a remote-less branch."
+
+The remote branch is **not** deleted. When another worktree holds the branch,
+`gh pr merge --delete-branch` deletes **neither** branch — the local-delete error
+ends the operation with the remote still alive.
+
+### Evidence (verified both directions, one session, gh 2.88.0)
+
+| Case | n | Remote branch after merge |
+|---|---|---|
+| `--delete-branch` succeeded | 6 | deleted (0 present) — correct |
+| `--delete-branch` hit the worktree error | 3 | **still alive** |
+
+Occurrences: #63 `improve/negative-test-every-guardrail`, #66
+`fix/close-archive-detection`, #68 `chore/rescue-orphaned-transcripts`. Each needed a
+manual `git push origin --delete`. Verified with `git ls-remote --heads` after
+`git fetch --prune` — authoritative, not the local `git branch -r` cache.
+
+### Why a wrong rule is worse than no rule
+
+The claim doesn't merely fail to help — it **actively suppresses the check**. It says
+"harmless," so you don't verify, so the surviving branch is never noticed. A missing
+rule would have left normal curiosity intact. This is the "Is every rule still TRUE?"
+demotion-checklist case (added 0.24.0) landing on the playbook's own docs.
+
+### The systemic upgrade — fix it at the repo, not in prose
+
+The stronger fix isn't a better instruction, it's removing the need for one. This repo
+has **`delete_branch_on_merge: false`**, so GitHub never auto-deletes a merged head
+branch. Enabling it makes the whole failure mode moot, including for web-UI merges.
+
+**Honest scoping of the impact.** An audit found **24 stale remote branches**, all from
+merged PRs back to 2026-04. Do *not* attribute all 24 to the gh bug — most predate it and
+come from merges that simply never passed `--delete-branch`, compounded by
+`delete_branch_on_merge: false`. Two distinct causes, one repo-level fix:
+
+| Cause | Fix |
+|---|---|
+| `--delete-branch` half-fails when a worktree holds the branch | Verify + `git push origin --delete` (documented in Step 4) |
+| Merges that never used `--delete-branch` at all | `delete_branch_on_merge: true` — covers both |
+
+### Updated rule of thumb
+
+| Signal | Old response | New response |
+|---|---|---|
+| `failed to delete local branch …used by worktree` | Ignore — "remote is still deleted" | `git ls-remote --heads origin <b>`; delete it yourself if present |
+| Repo accumulating merged branches | (not covered) | Check `gh repo view --json deleteBranchOnMerge`; enable it |
+
+### Addendum action items
+
+- [x] `/playbook:monitor-pr` Step 4: claim corrected, verification snippet + repo-level fix added (0.24.4)
+- [ ] **Enable `delete_branch_on_merge` on this repo** — repo setting, needs owner action
+- [ ] Sweep the 24 stale remote branches (two are held by live worktrees — leave those)

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
@@ -213,7 +213,28 @@ Every PR — **especially autonomously merged ones** — gets a proof-of-complet
 
 Post it immediately before `gh pr merge`. If you find an already-merged PR missing one (e.g., during close-out), post it retroactively. Other workflows reference this section as "proof-of-completion comment (`/playbook:monitor-pr` Step 4)".
 
-> **Post-merge local state**: `gh pr merge --delete-branch` silently switches your local checkout to the default branch (and pulls) after deleting the PR branch. In a parallel-agent workspace this can strand your session on the wrong branch — re-checkout your working branch afterwards. If another worktree holds the PR branch, the local delete fails with a warning; that's harmless (the remote branch is still deleted), but the other checkout is left on a branch that no longer exists remotely — worth flagging for cleanup.
+> **Post-merge local state**: `gh pr merge --delete-branch` silently switches your local checkout to the default branch (and pulls) after deleting the PR branch. In a parallel-agent workspace this can strand your session on the wrong branch — re-checkout your working branch afterwards.
+>
+> **If another worktree holds the PR branch, `--delete-branch` half-fails — it deletes NEITHER branch.** You get `failed to delete local branch <b>: cannot delete branch '<b>' used by worktree at <path>`, and the operation ends with the **remote branch still alive**. The PR is merged, so the message reads as cosmetic and is easy to walk past. Verify and finish the job by hand:
+>
+> ```bash
+> gh pr merge <N> --merge --delete-branch          # may print the worktree error
+> git fetch -q origin --prune
+> git ls-remote --heads origin <branch> | wc -l    # MUST be 0; if 1, it survived
+> git push origin --delete <branch>                # finish the delete yourself
+> ```
+>
+> Check with `git ls-remote` (authoritative), not `git branch -r`, which reads a possibly-stale local cache.
+>
+> *Corrected 2026-07-26. This note previously said the local-delete failure was "harmless (the remote branch is still deleted)" — false, and the wrong version was load-bearing: it tells you not to look, so the surviving branch is never noticed. Verified both directions in one session (gh 2.88.0): 6 merges where `--delete-branch` succeeded left 0 remote branches; every merge that hit the worktree error left the remote branch alive (3 occurrences).*
+>
+> **Better, fix it at the repo level**: with `delete_branch_on_merge: true` (Settings → General → "Automatically delete head branches") GitHub deletes the head branch on every merge and this failure mode disappears — including for web-UI merges. Check with `gh repo view --json deleteBranchOnMerge`. A repo with it `false` silently accumulates merged branches; audit with:
+>
+> ```bash
+> for b in $(git ls-remote --heads origin | awk '{print $2}' | sed 's|refs/heads/||'); do
+>   gh pr list --head "$b" --state merged --limit 1 --json number --jq ".[0].number" | grep -q . && echo "stale: $b"
+> done
+> ```
 
 ### Step 5: False-Green Sanity Check
 


### PR DESCRIPTION
`/playbook:monitor-pr` Step 4 has shipped a **factually wrong** claim since 0.22.5. Found by hitting it three times in one session.

## The false claim

> If another worktree holds the PR branch, the local delete fails with a warning; that's harmless (**the remote branch is still deleted**)

The remote branch is **not** deleted. When another worktree holds the branch, `gh pr merge --delete-branch` deletes **neither** branch — the local-delete error ends the operation with the remote alive.

## Why this one mattered more than an ordinary typo

The claim doesn't just fail to help, it **actively suppresses the check**. It says "harmless," so you don't verify, so the surviving branch is never noticed. A *missing* rule would have left normal curiosity intact. This is exactly the "Is every rule still TRUE? — a wrong rule is worse than a missing one" case added in 0.24.0, landing on the playbook's own docs.

## Verified in both directions (gh 2.88.0)

Per the "negative-test every guardrail" rule from 0.24.0:

| Case | n | Remote branch after merge |
|---|---|---|
| `--delete-branch` succeeded | 6 | deleted (0 present) — correct |
| `--delete-branch` hit the worktree error | 3 | **still alive** |

Occurrences: #63 `improve/negative-test-every-guardrail`, #66 `fix/close-archive-detection`, #68 `chore/rescue-orphaned-transcripts` — each needed a manual `git push origin --delete`. Checked with `git ls-remote --heads` after `git fetch --prune` (authoritative), not `git branch -r` (stale local cache).

## Two root causes, honestly separated

An audit found **24 stale remote branches** from merged PRs going back to 2026-04. I initially assumed the gh bug explained them — it doesn't. Probing the repo first (per the "probe the live system before blaming config" rule merged today as 0.23.2) showed `delete_branch_on_merge: false`, so most come from merges that never passed `--delete-branch` at all.

| Cause | Fix |
|---|---|
| `--delete-branch` half-fails when a worktree holds the branch | Verify + `git push origin --delete` (now in Step 4) |
| Merges that never used `--delete-branch` | `delete_branch_on_merge: true` — covers both |

Step 4 now documents the corrected behavior, a verification snippet, the repo-level fix, and an audit command.

## Also

Appends a dated second-incident addendum to `docs/learnings/2026-07-17-merging-stacked-prs-across-worktrees.md`, where the false claim originated, and strikes through the wrong sentence in the original section with a pointer — so nobody reading only the top of that doc picks the error back up.

## Follow-up needing your action

- [ ] **Enable `delete_branch_on_merge`** on this repo (Settings → General → "Automatically delete head branches") — repo setting, I can't flip it for you
- [ ] Sweep the 24 stale remote branches (two are held by live worktrees — leave those)

🤖 Generated with [Claude Code](https://claude.com/claude-code)