### PR TITLE
fix(monitor-pr): --delete-branch half-fail isn't worktree-specific

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.24.4"
+      "version": "0.24.5"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.5] - 2026-07-26
+
+### Fixed
+- **`/playbook:monitor-pr` Step 4 — the `--delete-branch` half-fail isn't worktree-specific** — 0.24.4 (one version earlier, same session) described the trigger as "another worktree holds the PR branch". Too narrow: **any** failure in gh's post-merge local cleanup produces the same half-fail, leaving the remote branch alive. A second trigger was hit immediately — a **dirty working tree**, which blocks the switch to the default branch (`Please commit your changes or stash them before you switch branches. Aborting`).
+
+  Found while merging PR #69, the very PR that corrected this note: its own merge hit the new trigger. Running total is 4 occurrences, of which 3 were the worktree case and 1 the dirty-tree case.
+
+  Step 4 now lists both triggers with their distinct error messages and instructs treating *any* non-empty error from `gh pr merge --delete-branch` as "the remote branch probably survived — verify", rather than pattern-matching one message.
+
 ## [0.24.4] - 2026-07-26
 
 ### Fixed

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
@@ -215,10 +215,15 @@ Post it immediately before `gh pr merge`. If you find an already-merged PR missi
 
 > **Post-merge local state**: `gh pr merge --delete-branch` silently switches your local checkout to the default branch (and pulls) after deleting the PR branch. In a parallel-agent workspace this can strand your session on the wrong branch — re-checkout your working branch afterwards.
 >
-> **If another worktree holds the PR branch, `--delete-branch` half-fails — it deletes NEITHER branch.** You get `failed to delete local branch <b>: cannot delete branch '<b>' used by worktree at <path>`, and the operation ends with the **remote branch still alive**. The PR is merged, so the message reads as cosmetic and is easy to walk past. Verify and finish the job by hand:
+> **If anything blocks gh's post-merge local cleanup, `--delete-branch` half-fails — it deletes NEITHER branch.** The PR merges, then the local step fails, and the operation ends with the **remote branch still alive**. Because the merge itself succeeded, the message reads as cosmetic and is easy to walk past. At least two distinct triggers, both observed:
+>
+> - **Another worktree holds the branch** — `failed to delete local branch <b>: cannot delete branch '<b>' used by worktree at <path>`
+> - **The working tree is dirty**, so gh can't switch you to the default branch — `Please commit your changes or stash them before you switch branches. Aborting`
+>
+> Don't pattern-match on the specific message. Treat *any* non-empty error from `gh pr merge --delete-branch` as "the remote branch probably survived" and verify. Finish the job by hand:
 >
 > ```bash
-> gh pr merge <N> --merge --delete-branch          # may print the worktree error
+> gh pr merge <N> --merge --delete-branch          # may print a local-cleanup error
 > git fetch -q origin --prune
 > git ls-remote --heads origin <branch> | wc -l    # MUST be 0; if 1, it survived
 > git push origin --delete <branch>                # finish the delete yourself
@@ -226,7 +231,7 @@ Post it immediately before `gh pr merge`. If you find an already-merged PR missi
 >
 > Check with `git ls-remote` (authoritative), not `git branch -r`, which reads a possibly-stale local cache.
 >
-> *Corrected 2026-07-26. This note previously said the local-delete failure was "harmless (the remote branch is still deleted)" — false, and the wrong version was load-bearing: it tells you not to look, so the surviving branch is never noticed. Verified both directions in one session (gh 2.88.0): 6 merges where `--delete-branch` succeeded left 0 remote branches; every merge that hit the worktree error left the remote branch alive (3 occurrences).*
+> *Corrected 2026-07-26. This note previously said the local-delete failure was "harmless (the remote branch is still deleted)" — false, and the wrong version was load-bearing: it tells you not to look, so the surviving branch is never noticed. Verified both directions in one session (gh 2.88.0): 6 merges where `--delete-branch` succeeded left 0 remote branches; all 4 merges whose local cleanup errored left the remote branch alive. The 4th arrived while merging the very PR that fixed this note — via the dirty-working-tree trigger rather than the worktree one, which is how the "any error, not just the worktree message" generalization was found.*
 >
 > **Better, fix it at the repo level**: with `delete_branch_on_merge: true` (Settings → General → "Automatically delete head branches") GitHub deletes the head branch on every merge and this failure mode disappears — including for web-UI merges. Check with `gh repo view --json deleteBranchOnMerge`. A repo with it `false` silently accumulates merged branches; audit with:
 >


### PR DESCRIPTION
Follow-up to #69 (0.24.4), found by #69's own merge.

## What was too narrow

0.24.4 described the `--delete-branch` half-fail as happening when "another worktree holds the PR branch". That's one trigger, not the condition. **Any** failure in gh's post-merge local cleanup produces the same outcome — PR merged, local step aborts, remote branch still alive.

The second trigger showed up immediately, while merging #69 itself:

```
$ gh pr merge 69 --merge --delete-branch
Please commit your changes or stash them before you switch branches.
Aborting
```

A dirty working tree (an in-flight SpecStory transcript) blocked the switch to the default branch. Different message, no worktree involved, same result — verified with `git ls-remote`:

```
=== did the merge actually land? ===
MERGED 2026-07-27T02:59:03Z
=== remote branch survived? ===
present: 1
```

Fourth manual `git push origin --delete` of the session.

## The fix

Step 4 now lists both triggers with their distinct error text, and — more importantly — says not to pattern-match the message at all:

> Treat *any* non-empty error from `gh pr merge --delete-branch` as "the remote branch probably survived" and verify.

Matching on one message is what made 0.24.4 incomplete; a reader who saw the dirty-tree error would not have recognized it as the documented case.

## Running tally (gh 2.88.0)

| Outcome | n | Remote branch after merge |
|---|---|---|
| `--delete-branch` succeeded | 6 | deleted — correct |
| local cleanup errored (3 worktree, 1 dirty-tree) | 4 | **still alive** |

## Note

Two consecutive patch versions correcting the same paragraph is not ideal, but the second trigger was only observable by *using* the first fix. The underlying repo-level fix from #69 still stands as the real answer:

- [ ] **Enable `delete_branch_on_merge`** — makes every variant of this moot

🤖 Generated with [Claude Code](https://claude.com/claude-code)