### PR TITLE
improve(close): latest.md freshness check before overwriting

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.24.5"
+      "version": "0.24.6"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.6] - 2026-07-27
+
+### Added
+- **`/playbook:close` step 4 — freshness check before claiming `latest.md`** — Step 4 previously only asked *whose* the existing checkpoint was; it never asked *when* it was written. In a multi-session workspace `latest.md` can hold a **newer** session's handoff than the one being closed, and overwriting the freshest handoff with an older-scoped one is backwards. Now compares the existing checkpoint's `**Date**:` against the closing session and, when the existing one is newer, writes the closing session's checkpoint as a dated archive and leaves `latest.md` alone. `latest.md` should be the most recent handoff for the workspace, not the most recently *written* one. (chef-chopsky, 2026-07-25: closing a 7/08–7/20 arc found a 7/25 checkpoint from a successor thread.)
+
+  The `ALREADY_ARCHIVED` branch of the 0.24.2 tri-state check now points at the freshness check explicitly — "archived somewhere" does not imply "older than you", so a newer handoff could otherwise be archived *and* overwritten.
+
 ## [0.24.5] - 2026-07-26
 
 ### Fixed

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.24.5",
+  "version": "0.24.6",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
@@ -123,6 +123,16 @@ You are facilitating an end-of-session close-out. Run each phase in order. Skip 
    workspace and topic. Only skip archiving if the existing checkpoint is demonstrably yours
    (its branch matches the one this session has been working on).
 
+   **Freshness check before claiming `latest.md` (even when it's yours):** compare the
+   existing checkpoint's `**Date**:` against the session being closed. In a multi-session
+   workspace, `latest.md` may hold a NEWER session's handoff than the one you are closing
+   (hit on chef-chopsky, 2026-07-25: close-out of a 7/08-7/20 arc found a 7/25 checkpoint
+   from a successor thread). Overwriting the freshest handoff with an older-scoped one is
+   backwards - in that case write YOUR checkpoint as the dated archive file
+   (`docs/checkpoints/<date>-<topic>.md`) and leave `latest.md` untouched. `latest.md`
+   should always be the most recent handoff for the workspace, not the most recently
+   *written* one.
+
 5. Write to `docs/checkpoints/latest.md` using the session-checkpoint format:
 
 ```markdown

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
@@ -93,7 +93,9 @@ You are facilitating an end-of-session close-out. Run each phase in order. Skip 
    ```
 
    - `NO_EXISTING_CHECKPOINT` → nothing to archive; go straight to step 5.
-   - `ALREADY_ARCHIVED` → safe to overwrite in step 5.
+   - `ALREADY_ARCHIVED` → safe to overwrite in step 5 — **but run the freshness check below
+     first.** "Archived somewhere" does not mean "older than you": a newer session's handoff
+     can be both already archived and the one that should stay in `latest.md`.
    - `ARCHIVE_REQUIRED` → rename it first, do NOT overwrite:
 
    ```bash


### PR DESCRIPTION
Phase 3/step 4 assumed the closing session's checkpoint becomes latest.md. In multi-session workspaces, latest.md can hold a NEWER session's handoff than the one being closed. Adds a date-comparison rule: when the existing checkpoint is newer, write the closing session's checkpoint as a dated archive and leave latest.md alone. Grounded: chef-chopsky 2026-07-25 growth-empowerment close-out (chef-chopsky PR #448).

🤖 Generated with [Claude Code](https://claude.com/claude-code)