### PR TITLE
feat(templates): gate watch windows state their evidence, not just a duration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.24.6"
+      "version": "0.24.7"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.7] - 2026-07-27
+
+### Added
+- **`tasks` template — time-based gates state the evidence they're waiting for, not just a duration** — A gate written as "watch metric X for N hours" is really a *sample-size* gate wearing a clock. At low traffic the information value saturates long before the duration expires; at high traffic the clock can expire before enough samples arrive. Either way the number inherited from the plan stops tracking what the gate is actually for.
+
+  Watch windows are now written as `[N hours] OR [the evidence] — whichever arrives first`, with the evidence named up front (e.g. "one full token-refresh cycle past the last pre-change session + ≥K post-change logins with 0 error events"). Early closure requires that stated evidence plus the gate owner's sign-off, and the decision line now records the rationale whenever the window deviates from its stated duration — in either direction. (Single-domain cutover, 2026-07-27: a 48h auth watch saturated in ~12h at 2-users/week scale.)
+
 ## [0.24.6] - 2026-07-27
 
 ### Added

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/resources/templates/tasks.md
+++ b/plugins/product-playbook-for-agentic-coding/resources/templates/tasks.md
@@ -106,10 +106,14 @@
 - [ ] Confirm every metric returns a non-null real number (not "no data," not `null`, not "unable to measure")
 - [ ] If any metric is unmeasurable: STOP. Fix the instrumentation, re-run the dry-run, and only then proceed to the gate review.
 
+**Watch window** (for time-based gates — "watch metric X for N hours/days"):
+- State the window as the **evidence it is waiting for**, not just a duration: `[N hours] OR [the evidence: e.g. "one full token-refresh cycle past the last pre-change session + ≥K post-change logins with 0 error events"] — whichever arrives first`
+- A fixed duration inherited from a plan is really a *sample-size* gate. At low traffic the information value saturates long before the clock (a 48h auth watch saturated in ~12h at 2-users/week scale, single-domain cutover 2026-07-27); at high traffic the clock may expire before enough samples arrive. Early closure requires the evidence stated up front + the gate owner's sign-off, recorded in the decision line.
+
 **Acceptance Criteria**:
 - [ ] All metrics dry-run successfully (non-null values)
 - [ ] All metrics meet their thresholds (or explicit conditional-GO with named follow-up)
-- [ ] Decision recorded with date, owner, and follow-up tasks
+- [ ] Decision recorded with date, owner, and follow-up tasks (incl. early/late closure rationale if the watch window deviated from the stated duration)
 
 **Status**: [ ] Not Started | [ ] In Progress | [ ] Complete
 


### PR DESCRIPTION
From the chef-chopsky single-domain-cutover retrospective (2026-07-27, [learnings doc](https://github.com/daviswhitehead/chef-chopsky/blob/production/docs/learnings/2026-07-27-single-domain-cutover-session-learnings.md), insight #3):

The cutover plan specified a 48h post-cutover stability watch before the irreversible GSC change-of-address. At ~2 real logged-in users/week, the watch's information value saturated in hours — the token-refresh failure mode shows within ~1–2h of a login, and extra wall-clock added no returning-user samples. The gate closed at ~12h on **stated evidence** (0 loop events, 0 old-host pageviews, overnight logins clean) with founder approval.

The `[GATE]` template now asks time-based gates to (1) state the evidence the window is waiting for, closing on `duration OR evidence, whichever first`, and (2) record early/late-closure rationale in the decision line. This keeps the anti-rubber-stamp property (evidence must be pre-stated, owner signs off) while preventing cargo-cult wall-clock waits at low traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)