### PR TITLE
fix(guard): version-bump check passed a version REGRESSION

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.24.7"
+      "version": "0.24.8"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.8] - 2026-07-27
+
+### Fixed
+- **`scripts/check-version-bump.sh` green-lit a version *regression*** — The guard that exists to protect version-keyed propagation compared versions with a string inequality (`cur != base`), so **any** change passed, including a decrease. It printed `OK: product-playbook-for-agentic-coding bumped 0.24.7 -> 0.23.0` and exited 0 — calling a seven-release regression a "bump".
+
+  Not hypothetical: open PR #74 (a duplicate of the already-merged #59) carried content identical to `main` plus `"version": "0.23.0"`. CI was the only thing between it and `main`, and CI would have been green. It was caught by judgement, not by the guard built for it.
+
+  A backwards version is worse than an unbumped one: installs already on the higher version stop updating until the number climbs back past that high-water mark, a stall that outlasts the offending PR and is invisible from the repo.
+
+  Now uses a semver-aware comparison that fails closed on malformed or empty input, with a distinct `version went BACKWARDS` message naming the consequence. **Negative-tested in both directions**: 8 unit cases (including `0.10.0 > 0.9.0`, which a string sort gets wrong) and 4 end-to-end runs — backwards → exit 1, unchanged → exit 1, forward → exit 0, no-change → exit 0.
+
+### Added
+- **`/playbook:monitor-pr` — two mandatory checks before bulk-deleting branches** — (1) Deleting a branch closes its open PR, so re-derive the open-PR list *at delete time*, never from a list built earlier in the session. (2) Judge "merged" on **content, not ancestry** — squash-merge discards the branch's commits, so `git branch --merged` and `merge-base --is-ancestor` misreport in both directions.
+
+  Both fired in one 25-branch sweep (2026-07-27): the content check flagged two branches ancestry called deletable, and both had PRs opened mid-session; a third held the only complete copy of a file `main` had truncated — and only in its *local* ref. Also notes to check whether a local branch is ahead of its remote before deleting the remote.
+
 ## [0.24.7] - 2026-07-27
 
 ### Added

--- a/docs/learnings/2026-07-17-merging-stacked-prs-across-worktrees.md
+++ b/docs/learnings/2026-07-17-merging-stacked-prs-across-worktrees.md
@@ -127,5 +127,82 @@ come from merges that simply never passed `--delete-branch`, compounded by
 ### Addendum action items
 
 - [x] `/playbook:monitor-pr` Step 4: claim corrected, verification snippet + repo-level fix added (0.24.4)
-- [ ] **Enable `delete_branch_on_merge` on this repo** — repo setting, needs owner action
-- [ ] Sweep the 24 stale remote branches (two are held by live worktrees — leave those)
+- [x] **Enable `delete_branch_on_merge`** — done 2026-07-27 on this repo *and* chef-chopsky; verified via `gh repo view --json deleteBranchOnMerge` and by three subsequent merges cleaning up their own branches
+- [x] Sweep the stale remote branches — 21 remote + 7 local deleted 2026-07-27; 25 branches → 1
+
+---
+
+## 2026-07-27 third-incident addendum — the guard that green-lit a version *regression*
+
+The branch sweep this addendum's action items called for turned up two findings that
+belong here, one of them more serious than anything above.
+
+### 1. The version-bump guard passed a BACKWARDS bump
+
+`scripts/check-version-bump.sh` exists to protect version-keyed propagation. It compared
+versions with a string inequality:
+
+```bash
+if [ "$cur_version" = "$base_version" ]; then   FAIL
+else                                            OK: bumped $base -> $cur
+```
+
+So **any** change passed — including a decrease. Reproduced end-to-end:
+
+```
+OK: product-playbook-for-agentic-coding bumped 0.24.7 -> 0.23.0
+Version-bump check PASSED.     EXIT CODE: 0
+```
+
+It printed the word "bumped" for a seven-release regression and exited green.
+
+**This was not hypothetical.** PR #74 — a duplicate of the already-merged #59 — carried
+exactly this: content identical to `main`, plus `"version": "0.23.0"`. It was open, and CI
+was the only thing standing between it and `main`. It was caught by a human-style judgement
+call ("this looks like a duplicate"), not by the guard built to catch it.
+
+**Why backwards is worse than unchanged.** An unbumped change fails to propagate. A
+*backwards* version makes every install already on the higher version stop updating until
+the number climbs back past that high-water mark — a stall that outlasts the offending PR
+and is invisible from the repo.
+
+**Fix**: semver-aware `version_gt`, failing closed on malformed/empty input, with a distinct
+`version went BACKWARDS` failure message. Negative-tested in both directions — 8 unit cases
+(including `0.10.0 > 0.9.0`, which a string sort gets wrong) and 4 end-to-end runs:
+backwards → exit 1, unchanged → exit 1, forward → exit 0, no-change → exit 0.
+
+### 2. Branch sweeps need a content check and an open-PR check
+
+Ancestry-based "is it merged?" is unreliable under squash-merge, which this repo uses.
+`feat/instrumentation-acceptance-is-the-metric` reported unmerged with a 97-line diff while
+being 100% present in `main`. Judging on ancestry alone would have been wrong in both
+directions during one 25-branch sweep:
+
+- Two branches the content check flagged as "has unique content" turned out to have PRs
+  **opened mid-session** (#73, #74). Deleting a branch closes its PR — a list built an hour
+  earlier would have silently killed both.
+- One branch held the **only complete copy** of a session transcript that `main` had in
+  truncated form, and only in its *local* ref — the remote copy was already truncated.
+
+### Updated rule of thumb (cumulative)
+
+| Signal | Response |
+|---|---|
+| Guard says "OK: bumped A -> B" | Confirm B > A. "Changed" ≠ "increased". |
+| About to bulk-delete branches | Re-derive open PRs at delete time; compare file contents, not ancestry |
+| Branch looks unmerged | Check content — squash-merge discards ancestry |
+| Local branch ahead of its remote | The unique content may exist only locally |
+
+### Why the earlier prevention rules were insufficient
+
+Every rule above this line is about *branch* hygiene, and they worked. The regression slipped
+through a different layer: a guard whose own comparison was wrong. Documentation cannot catch
+that — only running the guard against the input it exists to reject can. This is the
+"negative-test every guardrail" rule (0.24.0) applied to a guard that predates it.
+
+### Third-addendum action items
+
+- [x] `scripts/check-version-bump.sh`: reject non-increasing versions, semver-aware, fail closed
+- [x] `/playbook:monitor-pr`: bulk-delete safety — open-PR check + content-not-ancestry check
+- [ ] Audit the repo's other guards the same way — has `validate-plugin.sh` ever been run
+      against input it should reject?

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.24.7",
+  "version": "0.24.8",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
@@ -241,6 +241,42 @@ Post it immediately before `gh pr merge`. If you find an already-merged PR missi
 > done
 > ```
 
+#### Before deleting any branch in bulk — two checks that are not optional
+
+Sweeping "already merged" branches looks like pure hygiene. Two things make it destructive:
+
+**1. Deleting a branch closes its open PR.** Always re-derive the open-PR list *at delete
+time*, never from a list built earlier in the session — PRs appear while you work.
+
+```bash
+OPEN=$(gh pr list --state open --json headRefName --jq '.[].headRefName')
+echo "$OPEN" | grep -qx "$b" && echo "SKIP $b — has an open PR"
+```
+
+**2. "Merged" must be judged on CONTENT, not ancestry.** Squash-merges discard the branch's
+commits, so `git branch --merged`, `merge-base --is-ancestor`, and a three-dot diff all
+report a fully-merged branch as unmerged — and, worse, the reverse can hide real work.
+Compare the files:
+
+```bash
+miss=0
+for f in $(git diff origin/main...origin/$b --name-only); do
+  if git cat-file -e "origin/main:$f" 2>/dev/null; then
+    n=$(diff <(git show "origin/main:$f") <(git show "origin/$b:$f") | grep -c '^>')
+  else n=1; fi                       # file absent from main entirely
+  miss=$((miss+n))
+done
+[ "$miss" -eq 0 ] && echo "safe to delete $b" || echo "KEEP $b — $miss line(s) not in main"
+```
+
+*Both fired in one sweep (2026-07-27, 25 branches): the content check flagged two branches
+that ancestry would have called deletable, and both turned out to have PRs opened
+mid-session. It also caught a branch holding the only complete copy of a file that `main`
+had in truncated form. Ancestry alone would have destroyed all three.*
+
+Also check whether a branch's local copy is ahead of its remote before deleting the remote —
+the unique content may exist **only** in the local ref.
+
 ### Step 5: False-Green Sanity Check
 
 Before declaring victory, verify that **path-filtered heavy jobs actually ran on the same head commit** as the fast-CI passes. Per CLAUDE.md's documented learnings on path-filtered false-greens:

--- a/scripts/check-version-bump.sh
+++ b/scripts/check-version-bump.sh
@@ -14,8 +14,14 @@
 #   scripts/check-version-bump.sh [base-ref]
 #     base-ref   git ref to diff against (default: origin/main)
 #
-# Exit 0 = all changed plugins bumped their version (or nothing changed).
-# Exit 1 = a plugin changed but its version did not bump.
+# Exit 0 = all changed plugins bumped their version FORWARD (or nothing changed).
+# Exit 1 = a plugin changed and its version did not INCREASE (unchanged, or went backwards).
+#
+# NOTE: "increase", not merely "differ". A backwards version is worse than an unchanged
+# one: because propagation is version-keyed, installs sitting on the old higher version
+# silently stop updating until the version climbs back past that high-water mark. This
+# check used a string `=` comparison until 2026-07-27 and cheerfully printed
+# "OK: bumped 0.24.7 -> 0.23.0". A real open PR (#74) would have shipped exactly that.
 
 set -uo pipefail
 
@@ -49,6 +55,20 @@ version_of() {  # version_of <git-ref-or-WORKING> <path>
     printf '%s' "$content" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version",""))' 2>/dev/null
 }
 
+# version_gt <a> <b> -> exit 0 if a is strictly greater than b, semver-aware.
+# Compares numerically per component so 0.10.0 > 0.9.0 (a plain string sort gets this
+# wrong). Non-numeric/malformed versions return 1 (not-greater), which fails closed.
+version_gt() {
+    python3 - "$1" "$2" <<'PY'
+import re, sys
+def parse(v):
+    m = re.match(r'^(\d+)\.(\d+)\.(\d+)', (v or '').strip())
+    return tuple(int(x) for x in m.groups()) if m else None
+a, b = parse(sys.argv[1]), parse(sys.argv[2])
+sys.exit(0 if (a is not None and b is not None and a > b) else 1)
+PY
+}
+
 echo "Checking version bumps against $BASE_REF (merge-base ${MERGE_BASE:0:8})..."
 echo "-------------------------------------------"
 
@@ -75,6 +95,12 @@ for plugin_json in plugins/*/.claude-plugin/plugin.json; do
         echo -e "${RED}FAIL: $name changed but version not bumped (still $cur_version)${NC}"
         echo -e "       Run: scripts/sync-version.sh <new-version> $name"
         FAILURES=$((FAILURES + 1))
+    elif ! version_gt "$cur_version" "$base_version"; then
+        echo -e "${RED}FAIL: $name version went BACKWARDS ($base_version -> $cur_version)${NC}"
+        echo -e "       Auto-update is version-keyed: installs on $base_version would stop"
+        echo -e "       updating until the version climbs back past $base_version."
+        echo -e "       Run: scripts/sync-version.sh <version greater than $base_version> $name"
+        FAILURES=$((FAILURES + 1))
     else
         echo -e "${GREEN}OK: $name bumped $base_version -> $cur_version${NC}"
     fi
@@ -82,8 +108,9 @@ done
 
 echo ""
 if [ "$FAILURES" -gt 0 ]; then
-    echo -e "${RED}Version-bump check FAILED ($FAILURES plugin(s) changed without a bump).${NC}"
-    echo "Auto-update is version-keyed: unbumped changes never reach users' installs."
+    echo -e "${RED}Version-bump check FAILED ($FAILURES plugin(s) without a forward version bump).${NC}"
+    echo "Auto-update is version-keyed: unbumped changes never reach users' installs,"
+    echo "and a backwards version stalls installs already on the higher one."
     exit 1
 fi
 echo -e "${GREEN}Version-bump check PASSED.${NC}"


### PR DESCRIPTION
## The bug

`scripts/check-version-bump.sh` exists to protect version-keyed propagation. It compared versions with a string inequality:

```bash
if [ "$cur_version" = "$base_version" ]; then   # FAIL
else                                            # OK: bumped $base -> $cur
```

So **any** change passed — including a decrease:

```
OK: product-playbook-for-agentic-coding bumped 0.24.7 -> 0.23.0
Version-bump check PASSED.     EXIT CODE: 0
```

It printed the word "bumped" for a seven-release regression and exited green.

## This was live, not hypothetical

**PR #74** — a duplicate of the already-merged #59 — carried exactly this shape: every content file byte-identical to `main`, plus `"version": "0.23.0"`. It was open today. CI was the only gate, and CI would have passed it. It got caught by a judgement call ("this looks like a duplicate"), not by the guard built to catch it.

**Backwards is worse than unbumped.** An unbumped change fails to propagate. A backwards version makes every install already on the higher version stop updating until the number climbs back past that high-water mark — a stall that outlives the offending PR and is invisible from the repo.

## Negative-tested in both directions

Per the "negative-test every guardrail" rule added in 0.24.0 — applied here to a guard that predates it.

**Unit (8 cases):**

| a vs b | result | note |
|---|---|---|
| 0.24.8 vs 0.24.7 | greater | |
| 0.23.0 vs 0.24.7 | NOT-greater | the bug |
| 0.24.7 vs 0.24.7 | NOT-greater | |
| 0.10.0 vs 0.9.0 | greater | **string sort gets this wrong** |
| 1.0.0 vs 0.99.99 | greater | |
| abc / empty / missing | NOT-greater | fails closed |

**End-to-end (content changed + version set to…):**

| version | exit | message |
|---|---|---|
| 0.23.0 | **1** | `FAIL: version went BACKWARDS (0.24.7 -> 0.23.0)` |
| 0.24.7 | 1 | `FAIL: changed but version not bumped` |
| 0.24.8 | 0 | `OK: bumped 0.24.7 -> 0.24.8` |
| (no change) | 0 | `OK: unchanged` |

## Also: branch-sweep safety in `/playbook:monitor-pr`

Two checks that are not optional before bulk-deleting branches:

1. **Deleting a branch closes its open PR** — re-derive the open-PR list *at delete time*, never from a list built earlier in the session.
2. **Judge "merged" on content, not ancestry** — squash-merge discards the branch's commits, so `git branch --merged` and `merge-base --is-ancestor` misreport in both directions.

Both fired in one 25-branch sweep today: the content check flagged two branches ancestry called deletable, and both had PRs opened mid-session (#73, #74). A third held the only complete copy of a file `main` had truncated — and only in its **local** ref.

## Open follow-up

- [ ] Audit the repo's other guards the same way. Has `validate-plugin.sh` ever been run against input it should *reject*?

🤖 Generated with [Claude Code](https://claude.com/claude-code)