### PR TITLE
feat(hooks): SessionStart orientation + executable close-project check (Phase 4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.24.8"
+      "version": "0.25.0"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-07-29
+
+### Added
+- **`SessionStart` hook — orientation without needing to be invoked** — The `session-start-status` skill exists because agents burn 10–30K tokens per session re-discovering the same context. But a skill only runs when someone remembers to invoke it, which makes "orient at session start" a suggestion rather than a behavior. `hooks/hooks.json` now runs `scripts/session-orientation.sh` unconditionally, gathering the deterministic half — branch and tracking state, uncommitted count, active `projects/in-progress/` dirs, latest checkpoint, last 3 commits, and any stashes tagged to this branch — with zero tool round-trips.
+
+  It surfaces stashes because that is how work actually gets lost: every commit is pushed, the branch reads clean, and the stash goes with the archived worktree.
+
+  Constraints, since this runs for every user in every session: fast (cheap git plumbing only), bounded (hard caps; 5 lines in practice), silent when irrelevant (no git repo, or no `projects/` and no `docs/checkpoints/` → prints nothing), and it always exits 0 so it can never fail a session. Opt out with `PLAYBOOK_NO_ORIENTATION=1`. The skill now defers to it and covers only the judgment half.
+
+- **`scripts/verify-close-project.sh` — the assertion that was missing** — `/playbook:close-project` Step 7 asked *"Project lives under `projects/done/[name]/`?"*. That was **true** during the failure it should have caught: `forgot-password` and `illustration-batch` were copied rather than moved, so they existed in **both** `in-progress/` and `done/` for ~3.7 months with every checklist item passing.
+
+  The missing assertion was never "did it land" but **"is the source gone"**. Step 7 is now a script that asserts it, plus no living references to the old path, the close-out artifact, and (best-effort, via `gh`) that merged PRs carry a proof-of-completion comment. A prose checkbox cannot catch this class, because the agent answering it is the same one that just performed the move.
+
+- **Hook validation in `validate-plugin.sh`** — hooks are the one component that runs in every session without being invoked, so a malformed one degrades every session silently. The validator now checks `hooks.json` parses, and that every `${CLAUDE_PLUGIN_ROOT}` script exists and is executable. Verified to fail on all three (missing script, non-executable, bad JSON), not just to pass when healthy.
+
+- **`scripts/test-close-project-checks.sh`** — 14 cases across both scripts, asserting both directions. The load-bearing case reproduces the exact 3.7-month bug shape and requires the checker to fail on it.
+
 ## [0.24.8] - 2026-07-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -183,6 +183,19 @@ by many plugins in Anthropic's official marketplace.
 | `user-journey-testing` | Patterns for user journey testing and validation |
 | `chat-insights` | Patterns for analyzing chat sessions to extract product insights |
 
+## Hooks & Checks
+
+Some things shouldn't depend on an agent remembering to do them. These run in the harness, or as scripts a command must execute.
+
+| Component | Kind | What it does |
+|---|---|---|
+| `hooks/hooks.json` → `scripts/session-orientation.sh` | `SessionStart` hook | Gathers branch/tracking state, uncommitted count, active `projects/in-progress/` dirs, latest checkpoint, last 3 commits, and stashes tagged to this branch — with no tool round-trips. Silent outside a git repo or in a repo without the playbook layout. Opt out with `PLAYBOOK_NO_ORIENTATION=1`. |
+| `scripts/verify-close-project.sh <name>` | Executable check | Asserts a close-out actually completed — above all that the **source directory is gone**, not merely that `done/` exists. |
+
+Run `scripts/test-close-project-checks.sh` after changing either (14 cases, both directions).
+
+**Why these are scripts rather than instructions**: `/playbook:close-project`'s checklist asked *"Project lives under `projects/done/`?"* — which was **true** while `forgot-password` and `illustration-batch` sat duplicated in both `in-progress/` and `done/` for ~3.7 months. The agent answering a checklist is the same one that just performed the move. A real guardrail has to be deterministic.
+
 ## Key Features
 
 ### Tool Discovery

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.24.8",
+  "version": "0.25.0",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/close-project.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/close-project.md
@@ -79,9 +79,9 @@ For each:
 
 `git mv projects/[in-progress|to-do]/[name] projects/done/[name]`
 
-Verify nothing else in the codebase points at the old path:
-- `grep -r "projects/in-progress/[name]" .` (or `to-do`) → expect zero hits in living docs
-- Any cross-references in CLAUDE.md, README, or other learnings docs need their paths updated
+**Move, never copy.** `git mv` does this correctly; copy-then-commit does not, and afterwards the difference is invisible unless you look for it. `forgot-password` and `illustration-batch` were copied, so they lived in **both** `in-progress/` and `done/` for ~3.7 months — while every Step 7 checklist item still read as passing, because "project lives under `done/`?" was *true*.
+
+Any cross-references in CLAUDE.md, README, or learnings docs need their paths updated. Step 7 asserts all of this — don't hand-verify it.
 
 ### Step 6: Trigger the Retrospective
 
@@ -91,13 +91,28 @@ Confirm with the user whether to run the retrospective inline:
 
 ### Step 7: Final Sanity Check
 
-Before declaring close-project done:
-- [ ] `planned-vs-implemented.md` exists in the project directory
+**Run the check — do not answer these from memory:**
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}"/scripts/verify-close-project.sh <project-name>
+```
+
+It asserts, and exits non-zero on any failure:
+
+| Assertion | Why it's mechanical, not a checkbox |
+|---|---|
+| `projects/done/<name>/` exists | The project landed |
+| **`projects/{in-progress,to-do}/<name>/` are GONE** | The assertion whose absence cost 3.7 months. A copy leaves both, and every prose checkbox still passes |
+| No living references to the old path | Excludes `done/` — historical references there are fine |
+| `planned-vs-implemented.md` present | The close-out artifact exists |
+| Merged PRs carry a proof-of-completion comment | Best-effort; skipped cleanly without `gh` or auth |
+
+Paste its output into the close-out summary. The agent answering a checklist is the same one that just did the move, which is exactly why this is a script.
+
+Then confirm by hand the things a script can't judge:
 - [ ] No tasks left in "Not Started" or "In Progress" status (every task has a final disposition)
 - [ ] No status drift between summary table and task detail sections
 - [ ] No orphan project artifacts at repo root
-- [ ] Project lives under `projects/done/[name]/`
-- [ ] Every merged PR for this project carries a proof-of-completion comment (`/playbook:monitor-pr` Step 4) — post retroactively if missing
 - [ ] Retrospective triggered or explicitly deferred with a tracking task
 
 ## Handoff to Retrospective

--- a/plugins/product-playbook-for-agentic-coding/hooks/hooks.json
+++ b/plugins/product-playbook-for-agentic-coding/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/session-orientation.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/product-playbook-for-agentic-coding/scripts/session-orientation.sh
+++ b/plugins/product-playbook-for-agentic-coding/scripts/session-orientation.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# SessionStart hook — deterministic session orientation.
+#
+# The session-start-status skill exists because agents burn 10-30K tokens per
+# session re-discovering the same context. But a skill only runs when someone
+# remembers to invoke it, which makes "orient at session start" a suggestion.
+# This gathers the same raw inputs unconditionally, in the harness, at ~zero
+# context cost, so the agent starts with them instead of spending five tool
+# round-trips fetching them.
+#
+# The skill is still the right tool for the *judgment* pass (what's the next
+# action, what's blocked). This just removes the fetching.
+#
+# Design constraints, because this runs for every user in every session:
+#   - Fast: only cheap git plumbing, no network, no file walks.
+#   - Bounded: hard caps on every list. Never dumps a large repo into context.
+#   - Silent when irrelevant: no git repo or no playbook layout -> print nothing.
+#   - Never fails the session: always exits 0.
+#
+# Opt out with PLAYBOOK_NO_ORIENTATION=1.
+
+# Format strings below contain literal markdown backticks, not command
+# substitution — the single quotes are deliberate.
+# shellcheck disable=SC2016
+
+set -uo pipefail
+
+[ "${PLAYBOOK_NO_ORIENTATION:-}" = "1" ] && exit 0
+command -v git >/dev/null 2>&1 || exit 0
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Any output at all is context cost, so bail unless this repo actually uses the
+# playbook layout. A plain repo gets nothing.
+[ -d projects ] || [ -d docs/checkpoints ] || exit 0
+
+branch=$(git branch --show-current 2>/dev/null || echo "detached")
+dirty=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+upstream=$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || true)
+if [ -n "$upstream" ]; then
+  counts=$(git rev-list --left-right --count "${upstream}...HEAD" 2>/dev/null || echo "0	0")
+  behind=$(printf '%s' "$counts" | cut -f1)
+  ahead=$(printf '%s' "$counts" | cut -f2)
+  track="${ahead} ahead / ${behind} behind ${upstream}"
+else
+  track="no upstream"
+fi
+
+printf '## Session orientation (auto)\n\n'
+printf -- '- **Branch**: `%s` — %s — %s uncommitted file(s)\n' "$branch" "$track" "$dirty"
+
+# Active projects. Capped: a long list is noise, and the count conveys the rest.
+if [ -d projects/in-progress ]; then
+  active=$(find projects/in-progress -maxdepth 1 -mindepth 1 -type d -exec basename {} \; 2>/dev/null | sort)
+  n=$(printf '%s\n' "$active" | grep -c . || true)
+  if [ "$n" -gt 0 ]; then
+    shown=$(printf '%s\n' "$active" | head -6 | tr '\n' ' ')
+    if [ "$n" -gt 6 ]; then
+      printf -- '- **In progress** (%s): %s… (+%s more)\n' "$n" "$shown" "$((n - 6))"
+    else
+      printf -- '- **In progress** (%s): %s\n' "$n" "$shown"
+    fi
+  fi
+fi
+
+# Freshest checkpoint, if the repo keeps them. Path only — reading it is the
+# agent's call, and it is usually higher signal than anything gathered here.
+if [ -f docs/checkpoints/latest.md ]; then
+  when=$(grep -m1 -E '^\*\*Date\*\*:' docs/checkpoints/latest.md 2>/dev/null | sed 's/\*\*Date\*\*:[[:space:]]*//' || true)
+  printf -- '- **Checkpoint**: `docs/checkpoints/latest.md`%s — higher signal than this summary; read it before re-deriving state\n' "${when:+ (${when})}"
+fi
+
+printf -- '- **Recent**: '
+git log --oneline -3 --no-decorate 2>/dev/null | sed 's/^/    /' | paste -sd '; ' - | sed 's/^ *//' || true
+printf '\n'
+
+# Stashes are the classic way work gets lost when a worktree or branch is
+# archived: every commit is pushed, so the branch reads "clean", and the stash
+# goes with the directory. Surface only stashes tagged to THIS branch.
+if [ -n "$branch" ]; then
+  stashes=$(git stash list 2>/dev/null | grep -c -E "(On|WIP on) ${branch}:" || true)
+  [ "${stashes:-0}" -gt 0 ] && \
+    printf -- '- ⚠️ **%s stash(es) on this branch** — `git stash list`. Pushed ≠ captured; check these before archiving the worktree.\n' "$stashes"
+fi
+
+exit 0

--- a/plugins/product-playbook-for-agentic-coding/scripts/test-close-project-checks.sh
+++ b/plugins/product-playbook-for-agentic-coding/scripts/test-close-project-checks.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Tests for verify-close-project.sh and session-orientation.sh.
+#
+#   scripts/test-close-project-checks.sh
+#
+# The important test is "reproduces the historical bug": a check that only ever
+# passes is a rubber stamp. verify-close-project.sh must FAIL when pointed at the
+# exact shape that went unnoticed for 3.7 months — the project present in BOTH
+# in-progress/ and done/ — and pass on a correct close.
+
+# 'cond && ok || bad' is intentional here: ok/bad are printf wrappers that
+# cannot fail, so the else-branch semantics are exactly what we want.
+# shellcheck disable=SC2015
+
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+VERIFY="${HERE}/verify-close-project.sh"
+ORIENT="${HERE}/session-orientation.sh"
+fails=0
+
+ok()   { printf 'PASS  %s\n' "$1"; }
+bad()  { printf 'FAIL  %s\n' "$1"; fails=$((fails + 1)); }
+
+# Build a throwaway repo with a given project layout.
+# usage: fixture <name> <tray-or-empty>   (tray="" means properly moved)
+fixture() {
+  local name="$1" tray="${2:-}"
+  local d; d="$(mktemp -d)"
+  ( cd "$d" \
+    && git init -q . \
+    && git config user.email t@t && git config user.name t \
+    && mkdir -p "projects/done/${name}" \
+    && echo "# diff" > "projects/done/${name}/planned-vs-implemented.md" \
+    && if [ -n "$tray" ]; then mkdir -p "projects/${tray}/${name}"; echo x > "projects/${tray}/${name}/tasks.md"; fi \
+    && git add -A && git commit -qm "fixture" ) >/dev/null 2>&1
+  printf '%s' "$d"
+}
+
+run_in() { ( cd "$1" && "$VERIFY" "$2" >/dev/null 2>&1; echo $? ); }
+
+echo "=== verify-close-project.sh ==="
+
+d=$(fixture alpha "")
+[ "$(run_in "$d" alpha)" = "0" ] && ok "clean close passes" || bad "clean close should pass"
+rm -rf "$d"
+
+# THE regression: forgot-password / illustration-batch shape.
+d=$(fixture beta "in-progress")
+rc=$(run_in "$d" beta)
+[ "$rc" != "0" ] && ok "duplicated in in-progress/ FAILS (the 3.7-month bug)" \
+                 || bad "duplicated in in-progress/ must fail, got rc=$rc"
+rm -rf "$d"
+
+d=$(fixture gamma "to-do")
+rc=$(run_in "$d" gamma)
+[ "$rc" != "0" ] && ok "duplicated in to-do/ FAILS" || bad "duplicated in to-do/ must fail, got rc=$rc"
+rm -rf "$d"
+
+# Never moved at all.
+d="$(mktemp -d)"
+( cd "$d" && git init -q . && git config user.email t@t && git config user.name t \
+  && mkdir -p projects/in-progress/delta && echo x > projects/in-progress/delta/tasks.md \
+  && git add -A && git commit -qm f ) >/dev/null 2>&1
+rc=$(run_in "$d" delta)
+[ "$rc" != "0" ] && ok "never moved FAILS" || bad "never moved must fail, got rc=$rc"
+rm -rf "$d"
+
+# Missing close-out artifact.
+d=$(fixture epsilon "")
+rm "$d/projects/done/epsilon/planned-vs-implemented.md"
+rc=$(run_in "$d" epsilon)
+[ "$rc" != "0" ] && ok "missing planned-vs-implemented.md FAILS" || bad "missing artifact must fail"
+rm -rf "$d"
+
+# A stale reference in a living doc.
+d=$(fixture zeta "")
+echo "see projects/in-progress/zeta/tasks.md" > "$d/README.md"
+rc=$(run_in "$d" zeta)
+[ "$rc" != "0" ] && ok "stale reference in a living doc FAILS" || bad "stale reference must fail"
+rm -rf "$d"
+
+# Historical references inside done/ are fine.
+d=$(fixture eta "")
+echo "was projects/in-progress/eta/" > "$d/projects/done/eta/history.md"
+rc=$(run_in "$d" eta)
+[ "$rc" = "0" ] && ok "historical reference inside done/ is allowed" || bad "done/ reference should not fail"
+rm -rf "$d"
+
+[ "$("$VERIFY" 2>/dev/null; echo $?)" = "64" ] && ok "missing arg exits 64" || bad "missing arg should exit 64"
+
+echo
+echo "=== session-orientation.sh ==="
+
+# Silent outside a git repo.
+d="$(mktemp -d)"
+out=$( cd "$d" && "$ORIENT" 2>/dev/null )
+[ -z "$out" ] && ok "silent outside a git repo" || bad "should print nothing outside a git repo"
+rm -rf "$d"
+
+# Silent in a git repo with no playbook layout — most repos.
+d="$(mktemp -d)"
+( cd "$d" && git init -q . ) >/dev/null 2>&1
+out=$( cd "$d" && "$ORIENT" 2>/dev/null )
+[ -z "$out" ] && ok "silent in a repo with no playbook layout" || bad "should print nothing without projects/"
+rm -rf "$d"
+
+# Emits in a playbook repo, and stays bounded.
+d=$(fixture theta "in-progress")
+out=$( cd "$d" && "$ORIENT" 2>/dev/null )
+printf '%s' "$out" | grep -q "Session orientation" && ok "emits in a playbook repo" || bad "should emit with projects/"
+lines=$(printf '%s\n' "$out" | wc -l | tr -d ' ')
+[ "$lines" -le 12 ] && ok "output bounded (${lines} lines)" || bad "output too long: ${lines} lines"
+rm -rf "$d"
+
+# Opt-out honored.
+d=$(fixture iota "in-progress")
+out=$( cd "$d" && PLAYBOOK_NO_ORIENTATION=1 "$ORIENT" 2>/dev/null )
+[ -z "$out" ] && ok "PLAYBOOK_NO_ORIENTATION=1 silences it" || bad "opt-out not honored"
+rm -rf "$d"
+
+# Never fails a session, even somewhere hostile.
+d=$(fixture kappa "")
+rm -rf "$d/.git"
+if ( cd "$d" && "$ORIENT" >/dev/null 2>&1 ); then
+  ok "exits 0 even with a broken repo"
+else
+  bad "must never fail the session"
+fi
+rm -rf "$d"
+
+echo
+if [ "$fails" -eq 0 ]; then echo "All checks passed."; else echo "${fails} FAILURE(S)"; fi
+exit "$fails"

--- a/plugins/product-playbook-for-agentic-coding/scripts/verify-close-project.sh
+++ b/plugins/product-playbook-for-agentic-coding/scripts/verify-close-project.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Executable close-out check for /playbook:close-project.
+#
+#   scripts/verify-close-project.sh <project-name>
+#
+# Why this exists
+# ---------------
+# close-project's Step 7 checklist asked "Project lives under projects/done/?"
+# — and that question was *true* during the failure it was supposed to catch.
+# forgot-password and illustration-batch were copied rather than moved, so they
+# sat in BOTH in-progress/ and done/ for ~3.7 months. Every checklist item
+# passed. The source directory was never asserted gone.
+#
+# A prose checkbox cannot catch that, because the agent answering it is the same
+# one that just did the copy. This asserts the invariant instead: after a close,
+# exactly ONE copy of the project exists, and it is the one under done/.
+#
+# Exits non-zero on any failure. Safe to run repeatedly.
+
+set -uo pipefail
+
+NAME="${1:-}"
+if [ -z "$NAME" ]; then
+  echo "usage: verify-close-project.sh <project-name>" >&2
+  exit 64
+fi
+
+fails=0
+pass() { printf '  \033[0;32mPASS\033[0m  %s\n' "$1"; }
+fail() { printf '  \033[0;31mFAIL\033[0m  %s\n' "$1"; fails=$((fails + 1)); }
+skip() { printf '  \033[0;33mSKIP\033[0m  %s\n' "$1"; }
+
+echo "Verifying close-out of '${NAME}'"
+echo
+
+# --- 1. It landed ------------------------------------------------------------
+if [ -d "projects/done/${NAME}" ]; then
+  pass "projects/done/${NAME}/ exists"
+else
+  fail "projects/done/${NAME}/ does not exist — the project never landed"
+fi
+
+# --- 2. THE ONE THAT MATTERS: the source is gone -----------------------------
+# This is the assertion whose absence cost 3.7 months of duplicated state.
+for tray in in-progress to-do; do
+  if [ -d "projects/${tray}/${NAME}" ]; then
+    fail "projects/${tray}/${NAME}/ STILL EXISTS — copied instead of moved. Use 'git mv', then delete the source."
+  else
+    pass "projects/${tray}/${NAME}/ is gone"
+  fi
+done
+
+# --- 3. Nothing living still points at the old paths -------------------------
+# Excludes done/ itself (historical references there are fine) and .git.
+stale=0
+for tray in in-progress to-do; do
+  hits=$(grep -rl --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=done \
+           "projects/${tray}/${NAME}" . 2>/dev/null | head -20 || true)
+  if [ -n "$hits" ]; then
+    fail "living references to projects/${tray}/${NAME}:"
+    while IFS= read -r hit; do
+      [ -n "$hit" ] && printf '           %s\n' "$hit"
+    done <<< "$hits"
+    stale=1
+  fi
+done
+[ "$stale" -eq 0 ] && pass "no living references to the old path"
+
+# --- 4. The close-out artifact exists ----------------------------------------
+if [ -f "projects/done/${NAME}/planned-vs-implemented.md" ]; then
+  pass "planned-vs-implemented.md present"
+else
+  fail "planned-vs-implemented.md missing from projects/done/${NAME}/"
+fi
+
+# --- 5. Merged PRs carry a proof-of-completion comment -----------------------
+# Autonomous merge authority is granted in exchange for a reviewable audit
+# trail; green CI is not that trail. Best-effort: needs gh, auth, and a remote.
+if ! command -v gh >/dev/null 2>&1; then
+  skip "proof-of-completion check (gh not installed)"
+elif ! gh auth status >/dev/null 2>&1; then
+  skip "proof-of-completion check (gh not authenticated)"
+else
+  prs=$(git log --oneline --all -- "projects/done/${NAME}" "projects/in-progress/${NAME}" "projects/to-do/${NAME}" 2>/dev/null \
+        | grep -oE '#[0-9]+' | tr -d '#' | sort -un | head -20 || true)
+  if [ -z "$prs" ]; then
+    skip "proof-of-completion check (no PR numbers found in this project's history)"
+  else
+    missing=""
+    for pr in $prs; do
+      state=$(gh pr view "$pr" --json state --jq .state 2>/dev/null || echo "")
+      [ "$state" = "MERGED" ] || continue
+      body=$(gh pr view "$pr" --json comments --jq '[.comments[].body] | join("\n")' 2>/dev/null || echo "")
+      printf '%s' "$body" | grep -qiE 'proof of completion|what shipped|proof-of-completion' \
+        || missing="${missing} #${pr}"
+    done
+    if [ -n "$missing" ]; then
+      fail "merged PR(s) missing a proof-of-completion comment:${missing}"
+      echo "           Post retroactively — see /playbook:monitor-pr Step 4."
+    else
+      pass "all merged PRs carry a proof-of-completion comment"
+    fi
+  fi
+fi
+
+echo
+if [ "$fails" -eq 0 ]; then
+  echo "Close-out verified."
+else
+  echo "${fails} check(s) failed — close-out is NOT complete."
+fi
+exit "$fails"

--- a/plugins/product-playbook-for-agentic-coding/skills/session-start-status/SKILL.md
+++ b/plugins/product-playbook-for-agentic-coding/skills/session-start-status/SKILL.md
@@ -23,6 +23,14 @@ This skill collapses that work into a single fixed pass that costs predictable t
 - Session-checkpoint skill already wrote `docs/checkpoints/latest.md` — that file is higher signal
 - One-shot question that doesn't depend on project state ("what's the syntax for X?")
 
+## Relationship to the SessionStart hook
+
+`hooks/hooks.json` runs `scripts/session-orientation.sh` at every session start. It gathers the **cheap, deterministic** half of the inputs below — branch and tracking state, uncommitted count, active `projects/in-progress/` dirs, latest checkpoint path, last 3 commits, and any stashes tagged to this branch — with no tool round-trips and without depending on anyone remembering to invoke anything.
+
+When that orientation block is already in context, **skip inputs 2, 3, and 5 below** — you have them. What remains is the part a shell script can't do: reading `tasks.md` for the in-flight task, reading the specstory tail for what the user was last asking about, and the judgment calls (blockers, suggested next step).
+
+If the block is absent — hook disabled via `PLAYBOOK_NO_ORIENTATION=1`, repo has no `projects/` or `docs/checkpoints/`, or the plugin isn't installed — run the full pass below.
+
 ## Process
 
 ### Inputs to Read (in order, in parallel where possible)

--- a/scripts/validate-plugin.sh
+++ b/scripts/validate-plugin.sh
@@ -190,6 +190,49 @@ fi
 
 echo ""
 
+# 5b. Validate hooks
+# A hook is the one component that runs every session without being invoked, so
+# a malformed one degrades every session silently for every user. Validate it.
+echo "Validating hooks..."
+echo "-------------------------------------------"
+
+HOOKS_FILE="$PLUGIN_DIR/hooks/hooks.json"
+if [ -f "$HOOKS_FILE" ]; then
+    if python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$HOOKS_FILE" 2>/dev/null; then
+        success "hooks.json is valid JSON"
+
+        # Every referenced script must exist and be executable, or the hook
+        # fails silently at session start.
+        while IFS=$'\t' read -r event relpath; do
+            [ -z "$event" ] && continue
+            if [ -z "$relpath" ]; then
+                warning "$event hook does not use \${CLAUDE_PLUGIN_ROOT} — may not resolve once installed"
+            elif [ ! -f "$PLUGIN_DIR$relpath" ]; then
+                error "$event hook references a missing script: $relpath"
+            elif [ ! -x "$PLUGIN_DIR$relpath" ]; then
+                error "$event hook script is not executable: $relpath"
+            else
+                success "$event hook -> $relpath (exists, executable)"
+            fi
+        done < <(python3 - "$HOOKS_FILE" <<'PYEOF'
+import json, re, sys
+d = json.load(open(sys.argv[1]))
+for event, entries in d.get("hooks", {}).items():
+    for entry in entries:
+        for h in entry.get("hooks", []):
+            m = re.search(r'\$\{CLAUDE_PLUGIN_ROOT\}"?(/[^\s"]+)', h.get("command", ""))
+            print(f"{event}\t{m.group(1) if m else ''}")
+PYEOF
+        )
+    else
+        error "hooks.json is not valid JSON"
+    fi
+else
+    warning "No hooks/hooks.json (optional)"
+fi
+
+echo ""
+
 # 6. Validate templates
 echo "Validating templates..."
 echo "-------------------------------------------"


### PR DESCRIPTION
Phase 4 of the Claude-setup work. The plugin was strong on commands (39), agents (9), and skills (10) and had **zero hooks** — so everything it knows depends on an agent *choosing* to act on it. These two are things that shouldn't.

## 1. `SessionStart` hook

`hooks/hooks.json` → `scripts/session-orientation.sh`.

The `session-start-status` skill exists because re-orientation costs 10–30K tokens per session. But a skill only runs **when someone remembers to invoke it**, which makes "orient at session start" a suggestion rather than a behavior.

The hook gathers the deterministic half unconditionally, with no tool round-trips: branch + tracking state, uncommitted count, active `projects/in-progress/` dirs, latest checkpoint, last 3 commits, and **any stashes tagged to this branch**. The skill now defers to it and keeps only the judgment half (in-flight task, blockers, next step).

The stash line is deliberate — that's how work actually gets lost. Every commit pushed, branch reads clean, stash goes with the archived worktree.

Because this runs for **every user in every session**:

| Constraint | How |
|---|---|
| Fast | Cheap git plumbing only. No network, no file walks |
| Bounded | Hard caps on every list — 5 lines in practice |
| Silent when irrelevant | No git repo, or no `projects/` **and** no `docs/checkpoints/` → prints nothing |
| Can never fail a session | Always exits 0 |
| Opt-out | `PLAYBOOK_NO_ORIENTATION=1` |

## 2. `scripts/verify-close-project.sh`

`close-project` Step 7 asked *"Project lives under `projects/done/[name]/`?"*

**That was `true` during the failure it was supposed to catch.** `forgot-password` and `illustration-batch` were copied rather than moved, so they sat in **both** `in-progress/` and `done/` for ~3.7 months — with every checklist item passing.

The missing assertion was never *"did it land"* but **"is the source gone"**. Step 7 is now a script asserting exactly that, plus no living references to the old path, the close-out artifact, and (best-effort via `gh`) proof-of-completion comments on merged PRs.

A prose checkbox structurally cannot catch this: the agent answering it is the same one that just performed the move.

## 3. Hook validation in `validate-plugin.sh`

A hook is the one component that runs in every session without being invoked, so a malformed one degrades every session **silently**. The validator now checks `hooks.json` parses and that every `${CLAUDE_PLUGIN_ROOT}` script exists and is executable.

Verified it **fails** on all three failure modes — missing script, non-executable, malformed JSON — not merely that it passes when healthy.

## Verification

`scripts/test-close-project-checks.sh` — **14 cases, both directions**:

```
=== verify-close-project.sh ===        8 PASS
  incl. duplicated in in-progress/ FAILS  <- reproduces the 3.7-month bug
        historical reference inside done/ is allowed
=== session-orientation.sh ===         6 PASS
  incl. silent in a repo with no playbook layout
        output bounded (5 lines)
        exits 0 even with a broken repo
```

`shellcheck` clean on all four scripts. `validate-plugin.sh`: 0 errors, 0 warnings.

## ⚠️ Found while running the version check — PR #78 has a version collision

`main` already shipped **0.24.8** on 2026-07-27 (`e0bfa07`, the version-regression guard fix). PR #78 was cut from a stale local `main` and bumps 0.24.7 → **0.24.8** — a version that already exists with different content.

This branch is off current `main`, so it correctly takes **0.25.0**. **#78 needs rebasing onto 0.24.9 before it can merge** — fixing that next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)