### PR TITLE
fix(close): archive untracks latest.md + guidance for autonomous learnings runs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.25.1"
+      "version": "0.25.2"
     },
     {
       "name": "openai-image-gen",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.25.0"
+      "version": "0.25.1"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.2] - 2026-07-29
+
+### Added
+- **`/playbook:learnings` — guidance for autonomous invocation** — Every facilitation gate in the workflow assumes a human is present: Step 1 asks the trigger type, Steps 6 and 9.1 ask for batch approval, Step 10 Part B asks the user for process observations. Invoked autonomously (a cron, a delegated subagent, or a user saying "run it autonomously"), those gates have no one to answer them.
+
+  The failure mode is **silent degradation, not an error**: the agent skips the question, picks a default nobody chose, and still reports success — the same "documented but never decided" pattern the workflow exists to prevent. Step 10 Part B is the worst case, since it's pure user input and historically produces the highest-value improvements.
+
+  New section prescribes: answer each gate in writing with reasoning rather than skipping it; default to executing anything reversible and refusing anything that isn't; ship as draft PRs so the PR *becomes* the deferred approval gate; mine the session's earlier user redirections in place of Part B's questions; and state plainly in the summary which gates were auto-answered. An autonomous run that reads identically to a facilitated one is hiding the decisions it made on someone's behalf. (Found 2026-07-29, chef-chopsky, running this workflow autonomously.)
+
 ## [0.25.1] - 2026-07-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-07-29
+
+### Fixed
+- **`/playbook:close` Phase 3 — step 4's archive silently untracks `latest.md`, flipping the staging decision** — `docs/checkpoints/latest.md` is normally *tracked*, so an early `git ls-files --error-unmatch` correctly reports "tracked, a plain `git add` works." Then step 4's `git mv` renames it, and the `latest.md` written afterwards is a **new, untracked** file at an ignored path. The correct branch flips mid-phase, and the earlier check is stale exactly when it's consulted.
+
+  Because `git add` aborts the *whole* invocation when any path is ignored, the already-staged rename then commits **alone** — yielding a "session checkpoint" commit containing the archive and not the handoff, with a clean exit code. The close-out reports success while the actual handoff sits untracked, one `git checkout` from deletion. (chef-chopsky, 2026-07-29.)
+
+  Phase 3 step 6 now says to run `git check-ignore` on the file immediately before staging, and to verify the commit contains **both** files via `git show --stat HEAD` rather than trusting the exit code. Also clarifies that a repo with an ignored `docs/checkpoints/` but tracked checkpoints is the normal case — `.gitignore` never applies to already-tracked files — so force-adding there *restores* the repo's convention rather than overriding it, and doesn't warrant the "ask first" treatment.
+
 ## [0.25.0] - 2026-07-29
 
 ### Added

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
@@ -195,8 +195,27 @@ You are facilitating an end-of-session close-out. Run each phase in order. Skip 
    git commit -m "chore: session checkpoint"
    ```
 
-   Three failure modes this closes, the first two hit in a real run (chef-chopsky,
-   2026-07-25):
+   **Do not decide `-f` vs plain `add` from a tracked-ness check you ran earlier in this
+   phase — step 4 invalidates it.** `latest.md` is normally *tracked*, so an early
+   `git ls-files --error-unmatch docs/checkpoints/latest.md` says "tracked, plain `add`
+   works" and that is true at the time. Then step 4's `git mv` renames it, and the
+   `latest.md` you write afterwards is a **new, untracked** file at an ignored path.
+   The correct branch flips mid-phase. Always run `git check-ignore` on the file
+   immediately before staging, as the snippet above does.
+
+   That is not hypothetical: chef-chopsky, 2026-07-29 — the early check reported
+   `TRACKED`, the plain `git add` then aborted on the ignored path (`git add` fails the
+   *whole* invocation, so the already-staged rename committed alone), and the commit
+   landed containing only the archive. The close-out would have reported success with
+   the actual handoff untracked and one `git checkout` from deletion. Note also that a
+   repo whose `docs/checkpoints/` is ignored but whose checkpoints are *tracked* is the
+   normal case, not a contradiction — `.gitignore` never applies to already-tracked
+   files, so force-adding there **restores** the repo's convention rather than
+   overriding it. Check whether siblings are tracked (`git ls-tree <default-branch>
+   docs/checkpoints/`) before treating `-f` as an override that needs permission.
+
+   Four failure modes this closes, the first two hit in a real run (chef-chopsky,
+   2026-07-25) and the fourth on 2026-07-29:
 
    - **`docs/checkpoints/` is frequently gitignored** ("local resume state"). A plain
      `git add` then silently stages *nothing*, `git commit` reports nothing to commit, and
@@ -213,6 +232,13 @@ You are facilitating an end-of-session close-out. Run each phase in order. Skip 
      buries them in a commit labelled "session checkpoint". That is the same
      other-agent-clobbering failure step 4 exists to prevent, in the opposite direction.
      Force-add the explicit file list, never the directory.
+   - **Step 4's archive silently flips `latest.md` from tracked to untracked**, so any
+     tracked-ness check from earlier in the phase is stale by the time you stage. And
+     because `git add` aborts the *entire* invocation when one path is ignored, the
+     already-staged rename commits by itself — producing a "session checkpoint" commit
+     that contains the archive and not the handoff. Always `git check-ignore` the file
+     immediately before staging, and verify the commit contains **both** files
+     (`git show --stat HEAD`) rather than trusting the exit code.
 
    When the path is gitignored, force-adding overrides a deliberate repo decision, so
    **ask** rather than defaulting. If the user wants checkpoints to stay local, skip the

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/learnings.md
@@ -941,6 +941,42 @@ For ALL identified improvements (from both agent self-reflection and user input)
 - Prior learnings search was missing — recurring patterns never got escalated (found during recipes retro)
 - Systemic analysis ("think bigger") step was missing — agent defaulted to incremental fixes (found during recipes retro)
 - Meta-retrospective was skippable — agent skipped it, losing the highest-value improvements (found during recipes retro)
+- Autonomous invocation turned every approval gate into a silent no-op (found 2026-07-29, chef-chopsky) — see below
+
+---
+
+## Running This Workflow Autonomously
+
+Every facilitation gate in this document assumes a human is present: Step 1 asks the
+trigger type, Steps 6/9.1 ask for batch approval, Step 10 Part B asks the user for
+process observations. When invoked autonomously ("run `/playbook:learnings`
+autonomously", a cron, or a delegated subagent), those gates have no one to answer them.
+
+**The failure mode is silent degradation, not an error.** The agent skips the question,
+picks a default nobody chose, and the retrospective still reports success — which is
+the same "documented but never decided" pattern this workflow exists to prevent. Worse,
+Step 10 Part B is where the highest-value improvements historically come from, and it is
+pure user input.
+
+When there is no human to ask:
+
+1. **Answer the gate yourself, in writing, with the reasoning.** Don't skip it — state
+   the choice and why. "Trigger: chat-session (passed as an argument). Output: both
+   targets, the default." A recorded decision is reviewable; a skipped one is invisible.
+2. **Default to executing, not deferring.** Approval gates exist to prevent unwanted
+   work, not to be the only path to any work. With no one to approve, the correct
+   reading of "Approve all?" is yes for anything reversible (docs, learnings, a draft
+   PR) and no for anything that isn't (merging, force-pushing, deleting).
+3. **Ship changes as draft PRs, never direct commits to the default branch.** The PR
+   *is* the deferred approval gate — it preserves the human decision point without
+   blocking the work.
+4. **Step 10 Part B becomes Part A-extended.** With no user to ask, the agent must
+   self-critique harder: where did the user redirect you *earlier in the session*? Those
+   redirections are the same signal Part B fishes for, and they already happened. Mine
+   the session, don't skip the step.
+5. **Say plainly in the final summary which gates were auto-answered**, so the human can
+   revisit any of them. An autonomous run that reads identically to a facilitated one is
+   hiding the decisions it made on someone's behalf.
 
 ---
 


### PR DESCRIPTION
Found by running this skill and having it fail on me.

## The trap

Phase 3 tells you to check whether the checkpoint path is ignored, then stage accordingly. **Step 4 changes the answer between the check and the staging.**

1. `docs/checkpoints/latest.md` is normally **tracked**. An early `git ls-files --error-unmatch` says *"tracked — a plain `git add` works."* True when run.
2. Step 4's `git mv` renames it to the dated archive.
3. The `latest.md` written afterwards is a **new, untracked** file at an ignored path.
4. The correct branch has flipped, and the earlier check is stale exactly when it's consulted.

Then it gets worse: `git add` aborts the **entire invocation** when any path is ignored. So the already-staged rename commits *by itself* — producing a `chore: session checkpoint` commit that contains the archive and **not the handoff**, with a clean exit code and no error the caller notices.

Net result: close-out reports success, the handoff is untracked at an ignored path, and one `git checkout` deletes it with no reflog entry. Which is precisely the failure Phase 3's existing guidance was written to prevent — reached by a different route.

## Fixes

- `git check-ignore` the **file** immediately before staging; never rely on a tracked-ness read from earlier in the phase
- Verify the commit contains **both** files (`git show --stat HEAD`) rather than trusting the exit code
- Clarify that *ignored directory + tracked checkpoints* is the **normal** case, not a contradiction — `.gitignore` never applies to already-tracked files. Force-adding there **restores** the repo's convention rather than overriding it, so it shouldn't trigger the "ask the user first" path. Check `git ls-tree <default-branch> docs/checkpoints/` to tell the two apart.

## Evidence

chef-chopsky, 2026-07-29. The commit landed as:

```
 .../2026-07-27-single-domain-closeout-salvador.md  | 48 ++++++++
 1 file changed, 48 insertions(+)
```

— archive only, no `latest.md`. Caught by checking `git show --stat` instead of the exit code, which is now what the skill tells you to do.

Version 0.25.1.