### PR TITLE
feat(close): org-deposit phase for agent-workforce repos

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.26.2"
+      "version": "0.26.3"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.3] - 2026-08-04
+
+### Added
+- **`/playbook:close` — Phase 3.5: Org Deposit (agent-workforce repos only)** — Skips silently
+  unless the repo defines an agent workforce (`workflows/TEAM.md` with role charters). When a
+  session was ad-hoc rather than run as a chartered 1:1, it asks which workforce employee should
+  have done the work and what lever, charter line, or prompt they were missing — then requires
+  that edit **before** closing, so the session compounds into the workforce instead of competing
+  with it. "None — founder-only on purpose" is a valid answer; silently skipping the question is
+  not. Phase 5's summary gains a matching `Org deposit:` line.
+
 ## [0.26.2] - 2026-08-04
 
 ### Fixed

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/close.md
@@ -247,6 +247,16 @@ You are facilitating an end-of-session close-out. Run each phase in order. Skip 
    is a fine choice to make on purpose — just not one to arrive at by a silent no-op, and
    not one to silently overrule either.
 
+## Phase 3.5: Org Deposit (agent-workforce repos only)
+
+Skip silently unless the repo defines an agent workforce (`workflows/TEAM.md` with role charters exists).
+
+If this session was an ad-hoc working session (not already run as a chartered 1:1), ask:
+
+> "Which workforce employee should have done this session's work — and what lever, charter line, or prompt were they missing?"
+
+Then **make that edit before closing** (the role's `CHARTER.md`, its prompts, `workflows/OBJECTIVES.md`, or a planned-hire note in `TEAM.md`), so the session compounds into the workforce instead of competing with it. If the work genuinely belongs to no role, record it as either a future hire (`TEAM.md` → planned evolution) or deliberately founder-only work. A one-line answer of "none — founder-only on purpose" is a valid outcome; silently skipping the question is not.
+
 ## Phase 4: Learn Flow
 
 1. If `--quick` or `--skip-learnings` was passed: skip this phase.
@@ -276,6 +286,7 @@ Git: [Committed 3 files / Clean / 2 uncommitted (noted)]
 Tasks: [2 completed, 1 carried forward / No tasks document]
 Handoff: docs/checkpoints/latest.md [committed <sha> / left local — path is gitignored]
          [archived prior checkpoint to <file>]
+Org deposit: [Edited growth/CHARTER.md / Founder-only on purpose / Not a workforce repo]
 Learnings: [Captured / Skipped]
 Skills: [Suggested /lore / Not applicable]
 ```


### PR DESCRIPTION
## What

Adds **Phase 3.5: Org Deposit** to `/playbook:close`, active only in repos that define an agent workforce (`workflows/TEAM.md` with role charters — currently chef-chopsky).

Before the learn flow, an ad-hoc session answers one question: *which workforce employee should have done this work, and what lever, charter line, or prompt were they missing?* — and makes that edit (charter, prompts, OBJECTIVES.md, or a planned-hire note) before closing. "None — founder-only on purpose" is a valid answer; silently skipping isn't. Phase 5 summary gains an `Org deposit:` line.

## Why

Part of the agent-workforce program: every ad-hoc session should deposit into the org so sessions compound toward wired-lever roles instead of remaining founder labor. Companion repo change: chef-chopsky#507 (FOUNDER-CADENCE.md + /1on1 skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)