### PR TITLE
fix(monitor-pr): check mergeStateStatus before interpreting checks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.26.3"
+      "version": "0.26.4"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.4] - 2026-08-04
+
+### Fixed
+- **`/playbook:monitor-pr` — check `mergeStateStatus` BEFORE interpreting any check results** —
+  When a PR is `DIRTY` (`mergeable: CONFLICTING`) it has no merge ref, so GitHub creates **zero**
+  `pull_request` workflow runs — while platform apps (Vercel/Supabase/Railway) still attach green
+  checks to the head commit. The check list looks healthy and nothing actually ran. Step 1 now
+  gates on `mergeStateStatus` first and corroborates with an empty `gh run list --branch`.
+  Grounding case: chef-chopsky #484, 2026-08-03 — two pushes, zero Actions runs, four green
+  platform checks. Fix is to merge the base branch in and push, which is what finally fires
+  Actions.
+
 ## [0.26.3] - 2026-08-04
 
 ### Added

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/monitor-pr.md
@@ -63,9 +63,18 @@ Rules that fall out of this hierarchy:
 ### Step 1: Snapshot Current State
 
 ```bash
-gh pr view <N> --json statusCheckRollup,state,isDraft,mergeable,headRefOid
+gh pr view <N> --json statusCheckRollup,state,isDraft,mergeable,mergeStateStatus,headRefOid
 gh run list --branch <BRANCH> --limit 5 --json databaseId,name,status,conclusion,createdAt,event
 ```
+
+**GATE — check `mergeStateStatus` BEFORE interpreting any check results.** If it is
+`DIRTY` (`mergeable: CONFLICTING`), the PR has no merge ref and GitHub creates **ZERO**
+`pull_request` workflow runs — while platform apps (Vercel/Supabase/Railway) still attach
+green checks to the head commit. The check list looks healthy; nothing actually ran.
+Corroborate with an empty `gh run list --branch <BRANCH>`. Fix: merge the base branch in,
+resolve conflicts, push — Actions will fire on that push. Do NOT read a conflicted PR's
+green platform checks as "CI passed." (Hit on chef-chopsky #484, 2026-08-03: two pushes,
+zero Actions runs, four green platform checks.)
 
 Classify each check into one of:
 


### PR DESCRIPTION
A PR with merge conflicts has no merge ref, so GitHub creates ZERO pull_request workflow runs — while platform apps (Vercel/Supabase/Railway) still attach green checks to the head commit. monitor-pr could read that as 'CI passed' when nothing ran. Adds a gate: check mergeStateStatus FIRST; DIRTY/CONFLICTING → resolve conflicts before trusting any check state. Hit for real on chef-chopsky #484 (two pushes, zero Actions runs, four green platform checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)