### PR TITLE
feat(merge-prs): autonomous PR-backlog command + enforce command-surface coverage (0.26.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.25.2"
+      "version": "0.26.0"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-08-04
+
+### Added
+- **`/playbook:merge-prs` — autonomous open-PR backlog clearing** — The capability had been
+  exercised twice by hand (4 PRs in 2026-07, 9 PRs in 2026-07-26) with the procedure split
+  across three places that nothing composed: `/playbook:monitor-pr` owned the per-PR merge
+  mechanics, CLAUDE.md held the stacked-bump ordering as prose, and a learnings doc held the
+  evidence. Every run re-derived the orchestration.
+
+  The command triages every open PR (including drafts — draft status is frequently neglect,
+  not intent), classifies each **MERGE / FIX-THEN-MERGE / SKIP / ESCALATE** with a stated
+  reason, orders the queue, then presents **one merge plan for one approval**. After that
+  gate it runs unattended. All human judgment is spent once, up front, where it belongs;
+  what follows is mechanical and long-running.
+
+  Design points that came from the two hand-run sessions:
+  - **Skip, don't halt.** A PR that breaks its triage assumptions mid-run is skipped and
+    reported; the remaining approved PRs still merge. Forfeiting eight good merges because
+    the fourth developed a conflict is the failure mode this prevents.
+  - **The plan file must not dirty the working tree.** A dirty tree is one of two known
+    triggers for `gh pr merge --delete-branch` half-failing and leaving the remote branch
+    alive. The plan goes to `docs/merge-plans/` with the path added to `.git/info/exclude`
+    (local, uncommitted, works in any git repo), and Step 5 asserts a clean tree before each
+    merge.
+  - **Version-guard machinery is detected, not assumed.** Sequential stacked bumps are
+    specific to repos with a version guard; the command looks for one and skips the whole
+    layer when absent.
+  - Worktree-aware branch claiming, and branch deletion verified with `git ls-remote` rather
+    than assumed.
+
+  It delegates per-PR CI work to `/playbook:monitor-pr` (which delegates failure analysis to
+  `/playbook:debug-ci`) rather than reimplementing either.
+
+### Fixed
+- **Command-surface drift, at the root cause** — Six real commands (`close`, `close-project`,
+  `emergent`, `foundations`, `monitor-pr`, `research-synthesis`) were missing from
+  `commands/help.md`, and four were missing from README's command tables. A command nobody
+  can find is worth nothing regardless of how good it is.
+
+  Root cause: both files hand-duplicate data that already lives in each command's
+  frontmatter, and adding a command has no step that touches either file. `validate-plugin.sh`
+  now enforces coverage **bidirectionally** — every command must appear in help.md and as a
+  README table row, and every `/playbook:x` referenced in help.md must resolve to a real
+  command. `plugin-guard.yml` already runs that script on every PR, so an unlisted command is
+  now unmergeable.
+
+  Generating help.md from frontmatter was considered and rejected: its value is the human
+  judgment about which command fits which situation, which no frontmatter field encodes.
+  Enforce coverage, leave the curation alone.
+
+  Notes: the README check requires a **table row**, not a prose mention — `close-project` was
+  named in README prose while absent from every table. The help.md check uses a `(?![\w-])`
+  lookahead so `/playbook:work` is not considered covered by `/playbook:work-multiple`. And
+  the coverage report is written to a temp file rather than captured through `$(...)`, because
+  bash 3.2 (still macOS's default `/bin/bash`) mis-parses a heredoc containing apostrophes
+  inside command substitution.
+
+- Content backfill: help.md gains the six missing commands plus `help`/`hello`, new
+  **Strategy Foundations**, **Close-Out**, **Pull Requests**, and **Meta** categories, and a
+  "Clearing a PR Backlog" workflow recipe. README gains `close-project`, `emergent`,
+  `monitor-pr`, `hello`, and a Pull Request Commands table.
+
 ## [0.25.2] - 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -97,14 +97,22 @@ by many plugins in Anthropic's official marketplace.
 | `/playbook:tasks` | Break down work into specific, actionable tasks |
 | `/playbook:work` | Execute the next task from the tasks document |
 | `/playbook:work-multiple` | Work autonomously on multiple tasks without interruption |
+| `/playbook:emergent` | Capture emergent in-flight scope as a micro-PRD before implementing |
 | `/playbook:learnings` | Capture learnings to improve docs and plugin |
 | `/playbook:close` | Session close-out — uncommitted work check, task cleanup, handoff context, learnings |
+| `/playbook:close-project` | Project close-out — planned-vs-implemented diff, move to `done/`, retrospective |
 
 ### Debugging & CI Commands
 | Command | Description |
 |---------|-------------|
 | `/playbook:debug` | Systematic debugging workflow |
 | `/playbook:debug-ci` | Debug CI/CD failures using GitHub CLI |
+
+### Pull Request Commands
+| Command | Description |
+|---------|-------------|
+| `/playbook:monitor-pr` | Drive one PR's CI to green autonomously with local-first fixes, then merge |
+| `/playbook:merge-prs` | Triage every open PR, approve one merge plan, then merge the queue autonomously |
 
 ### Design Commands
 | Command | Description |
@@ -154,6 +162,7 @@ by many plugins in Anthropic's official marketplace.
 | Command | Description |
 |---------|-------------|
 | `/playbook:help` | List all commands and find the right one for your task |
+| `/playbook:hello` | Verify the plugin installed correctly |
 
 ## Agents
 

--- a/docs/superpowers/specs/2026-08-04-merge-prs-and-help-coverage-design.md
+++ b/docs/superpowers/specs/2026-08-04-merge-prs-and-help-coverage-design.md
@@ -1,0 +1,126 @@
+# Design: `/playbook:merge-prs` + help.md drift guard
+
+**Date**: 2026-08-04
+**Status**: Approved, implementing
+**Ships in**: 0.26.0
+
+## Problem
+
+Two problems, both surfaced by the same question ("is there a workflow for carefully
+autonomously merging open PRs?").
+
+**1. No multi-PR merge workflow exists.** The capability has been exercised twice by hand
+(`docs/checkpoints/2026-07-17-merge-open-prs.md`, 4 PRs; `2026-07-26-merge-open-prs-v1.md`,
+9 PRs) and the procedure is written down in three disconnected places:
+
+- `/playbook:monitor-pr` — single-PR CI-to-green, owns the merge mechanics
+- `CLAUDE.md` → "Merging multiple open PRs (stacked bumps)" — the ordering procedure, as prose
+- `docs/learnings/2026-07-17-merging-stacked-prs-across-worktrees.md` — the evidence
+
+Nothing composes them. Every run re-derives the orchestration from prose.
+
+**2. `commands/help.md` drifts.** Six real commands were missing from it (`close`,
+`close-project`, `emergent`, `foundations`, `monitor-pr`, `research-synthesis`), plus
+`hello`/`help` themselves. Zero phantom entries — the failure is **omission only**.
+Root cause: help.md hand-duplicates data that already lives in each command's frontmatter,
+and adding a command has no step that touches help.md. README.md has the same drift
+(missing `close-project`, `emergent`, `monitor-pr`, `hello` as table rows).
+
+## Piece 1: `/playbook:merge-prs`
+
+### Shape
+
+A **command** at `commands/workflows/merge-prs.md` — user-invoked, matching `monitor-pr`'s
+house style. It is the *orchestration* layer only: per-PR CI triage is delegated to
+`/playbook:monitor-pr`, which in turn delegates failure analysis to `/playbook:debug-ci`.
+No logic is duplicated across the three.
+
+### Autonomy envelope: one gate up front
+
+Chosen over per-PR gating and full autonomy. The expensive judgment (is this draft
+complete? does this PR ship without its WIP? include the stranded work?) is all
+front-loaded into triage; once those calls are made the remaining execution is mechanical
+and long-running. Per-PR gating re-interrupts the user ~9 times for decisions already
+made. Full autonomy removes the one step where human judgment genuinely mattered.
+
+### Portability
+
+The stacked-version-bump procedure is specific to this repo. The command **detects**
+whether the repo has version-guard machinery (CLAUDE.md conventions, a sync/bump script, a
+guard workflow) and only layers per-PR bumps in when it finds it. Without one, it is
+simply an ordered merge queue. No hardcoded paths.
+
+### Flow
+
+| Step | What |
+|---|---|
+| 0 | Preflight — `gh auth status`, record starting branch, map `git worktree list`, read CLAUDE.md, detect version-guard machinery, check `deleteBranchOnMerge` |
+| 1 | Enumerate all open PRs including drafts |
+| 2 | Triage each → **MERGE / FIX-THEN-MERGE / SKIP / ESCALATE**, each with a stated reason |
+| 3 | Order the queue — oldest-first, overridden by file-overlap dependencies; assign one patch version per PR if a guard exists |
+| 4 | **The gate** — write the plan to a file, present it, wait for approval |
+| 5 | Execute — per PR: claim branch safely → merge main in → bump + CHANGELOG → local validation → push → `/playbook:monitor-pr` to green → proof-of-completion comment → merge → verify remote branch died → re-checkout → tick off in plan |
+| 6 | Exceptions — skip, don't halt |
+| 7 | Report — merged / skipped-with-reasons / final version / final main SHA / leftover branches |
+
+### Design decisions
+
+**The plan file must not leave the working tree dirty.** A dirty working tree is one of two
+documented triggers for `gh pr merge --delete-branch` half-failing and leaving the remote
+branch alive (`monitor-pr` Step 4, corrected 2026-07-26). Default: write to
+`docs/merge-plans/YYYY-MM-DD-merge-plan.md` and add that path to `.git/info/exclude`
+— local, uncommitted, portable to any git repo, keeps the tree clean. Alternative offered:
+commit it. Step 5 additionally asserts `git status --porcelain` is empty before each merge.
+
+**A broken PR skips, it does not halt the queue.** Halting everything because PR 4 of 9
+developed a conflict is the failure mode worth designing out — the remaining 5 are
+independent and already approved.
+
+**Branch claiming is worktree-aware.** `gh pr checkout` fails when any worktree of the
+shared repo holds the branch. Verify the other checkout is clean and at the PR head, then
+work from a temp branch and `git push origin HEAD:<branch>`. Never disturb the other
+worktree — it may be a live agent session.
+
+**Branch deletion is verified, not assumed.** Treat any non-empty error from
+`gh pr merge --delete-branch` as "the remote branch probably survived" and check with
+`git ls-remote` (authoritative), not `git branch -r` (stale cache).
+
+## Piece 2: help.md drift guard
+
+### Fix: validate, don't generate
+
+Extend `scripts/validate-plugin.sh` with a bidirectional coverage check:
+
+- every command's `name:` appears in help.md → catches omission (the observed failure)
+- every `/playbook:x` in help.md resolves to a real command → catches rename/delete drift
+- every command appears as a **table row** in README.md → catches the same drift on the
+  second surface (table row, not prose mention: `close-project` was mentioned in README
+  prose while absent from every table)
+
+`plugin-guard.yml` already runs `validate-plugin.sh` on every PR, so this needs no new CI
+wiring.
+
+### Rejected: generating help.md from frontmatter
+
+Would require adding a `category:` field to all 39 commands, and the valuable part of
+help.md is human judgment — *which* command for *which* situation, plus the workflow
+recipes. None of that is derivable from frontmatter. A generator would either destroy that
+content or become a template-with-holes. A coverage check makes drift unmergeable while
+leaving the curation intact, for ~40 lines in a script that already exists.
+
+### Content fixes
+
+help.md gains the 6 missing commands + `hello`/`help` + `merge-prs`. README gains
+`close-project`, `emergent`, `monitor-pr`, `hello`, `merge-prs` as table rows. The new
+check then enforces both surfaces — including the new command, so the two pieces of this
+change validate each other.
+
+## Version
+
+New command + new validation → **MINOR**: `0.25.2` → `0.26.0`.
+
+## Out of scope
+
+- Sweeping the ~20 stale remote branches noted in the 2026-07-26 checkpoint
+- Extending coverage checks to agents/skills (same class of drift, not observed yet)
+- Any change to `monitor-pr` or `debug-ci` beyond referencing them

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/help.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/help.md
@@ -14,6 +14,10 @@ Display all available commands and help the user find the right one for their ta
 
 ### Which Command Should I Use?
 
+**Starting a whole product, or don't know what to build yet?**
+→ `/playbook:foundations` - Mission, Vision, Personas, Engagement frameworks
+→ `/playbook:research-synthesis` - Turn research into ranked strategic opportunities
+
 **Starting a new feature or project?**
 → `/playbook:product-requirements` - Define WHAT to build and WHY
 
@@ -27,9 +31,20 @@ Display all available commands and help the user find the right one for their ta
 → `/playbook:work` - Execute the next task
 → `/playbook:work-multiple` - Execute multiple tasks autonomously
 
+**Scope changed mid-project?**
+→ `/playbook:emergent` - Capture a mid-flight bug or new requirement as a micro-PRD
+
 **Something broken?**
 → `/playbook:debug` - Systematic debugging workflow
 → `/playbook:debug-ci` - CI/CD specific failures
+
+**PR open, or a backlog of them?**
+→ `/playbook:monitor-pr` - Shepherd one PR's CI to green, then merge
+→ `/playbook:merge-prs` - Triage every open PR, approve one plan, merge the queue
+
+**Wrapping up?**
+→ `/playbook:close` - Session close-out: uncommitted work, handoff context, learnings
+→ `/playbook:close-project` - Project close-out: planned-vs-implemented diff, move to done/
 
 **Designing UI for a feature?**
 → `/playbook:design-system` - Extract your design system into DESIGN.md
@@ -69,6 +84,12 @@ Display all available commands and help the user find the right one for their ta
 
 ## All Commands by Category
 
+### Strategy Foundations
+| Command | When to Use |
+|---------|-------------|
+| `/playbook:foundations` | New product or strategy work - Mission, Vision, Personas, Engagement |
+| `/playbook:research-synthesis` | After research - synthesize quant + qual + taste into opportunities |
+
 ### Core Workflow (4-Phase)
 | Command | When to Use |
 |---------|-------------|
@@ -77,13 +98,26 @@ Display all available commands and help the user find the right one for their ta
 | `/playbook:tasks` | After tech plan - create specific, actionable tasks |
 | `/playbook:work` | Execute one task from the tasks document |
 | `/playbook:work-multiple` | Execute multiple tasks autonomously |
+| `/playbook:emergent` | Mid-project bug or new requirement - capture as a micro-PRD first |
 | `/playbook:learnings` | After completing work - capture insights for future |
+
+### Close-Out
+| Command | When to Use |
+|---------|-------------|
+| `/playbook:close` | End of a session - uncommitted work check, handoff context, learnings |
+| `/playbook:close-project` | Project finished - planned-vs-implemented diff, move to done/, retrospective |
 
 ### Debugging & CI
 | Command | When to Use |
 |---------|-------------|
 | `/playbook:debug` | Something isn't working - systematic debugging |
 | `/playbook:debug-ci` | CI/CD pipeline failures - GitHub Actions, tests |
+
+### Pull Requests
+| Command | When to Use |
+|---------|-------------|
+| `/playbook:monitor-pr` | One PR open - drive CI to green with local-first fixes, then merge |
+| `/playbook:merge-prs` | Backlog of open PRs - triage all, approve one plan, merge the queue |
 
 ### Design Pipeline
 | Command | When to Use |
@@ -128,6 +162,12 @@ Display all available commands and help the user find the right one for their ta
 | `/playbook:rubric` | Validate code quality against predefined rubrics |
 | `/playbook:rubric-doc` | Generate documents based on spec files with citations |
 
+### Meta
+| Command | When to Use |
+|---------|-------------|
+| `/playbook:help` | This command - find the right command for your task |
+| `/playbook:hello` | Verify the plugin installed correctly |
+
 ---
 
 ## Typical Workflows
@@ -140,7 +180,16 @@ Display all available commands and help the user find the right one for their ta
 4. /playbook:work                  → Execute tasks (repeat)
 5. /playbook:git-commit            → Commit changes
 6. /playbook:git-pr                → Create PR
-7. /playbook:learnings             → Capture what you learned
+7. /playbook:monitor-pr            → Drive CI to green, then merge
+8. /playbook:learnings             → Capture what you learned
+9. /playbook:close                 → Close out the session
+```
+
+### Clearing a PR Backlog
+```
+1. /playbook:merge-prs             → Triage every open PR, present one merge plan
+2. (approve the plan once)         → Queue merges autonomously from here
+3. /playbook:learnings             → Capture anything new about the merge mechanics
 ```
 
 ### UI Feature Development (with Design Pipeline)

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/merge-prs.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/merge-prs.md
@@ -1,0 +1,295 @@
+---
+name: playbook:merge-prs
+description: Triage every open PR, get one approval on a merge plan, then merge the whole queue autonomously — sequential version bumps, per-PR CI-to-green, verified branch cleanup
+argument-hint: "[optional: PR numbers to limit scope, e.g. \"57 58 61\"]"
+recommended-mode: auto-accept
+thinking-depth: deep
+---
+
+# Merge Open PRs
+
+You are clearing a repository's open-PR backlog. This command is the **orchestration**
+layer: it decides *what* gets merged and *in what order*, then drives each PR through
+`/playbook:monitor-pr`, which owns the per-PR CI and merge mechanics.
+
+## Your Goal
+
+Take every open PR, triage it, present one merge plan, and — after a single approval —
+merge the approved queue to completion without further questions.
+
+## The One Gate (Read This Before Doing Anything)
+
+**All human judgment is spent once, at Step 4.** Everything before it is analysis;
+everything after it is mechanical execution. This split is the whole point of the command:
+
+- Triage is where the expensive calls live — is this draft complete or abandoned? does
+  this PR ship without the WIP it references? whose branch is this?
+- Execution is long-running and boring — merge main in, bump, validate, push, wait for CI,
+  merge, verify. Nobody should babysit that.
+
+So: **do not ask the user anything after Step 4 succeeds.** If you hit something the plan
+didn't anticipate, apply Step 6 (skip and continue), don't stop and ask. The one exception
+is Step 6's escalation list — genuinely unsafe territory, where stopping is correct.
+
+## Available Tools
+
+- `/playbook:monitor-pr` — per-PR CI-to-green, proof-of-completion comment, merge
+  mechanics. **Call into it. Do not reimplement it.**
+- `/playbook:debug-ci` — systematic CI failure analysis. `monitor-pr` already delegates
+  here; you should not call it directly.
+- `gh` CLI — `pr list`, `pr view`, `pr diff`, `pr comment`, `pr merge`, `repo view`
+- `git worktree list`, `git ls-remote` — the two commands that keep you out of trouble in
+  a parallel-agent workspace
+
+## Process
+
+### Step 0: Preflight
+
+1. **Verify `gh` is authed**: `gh auth status`. Stop if not — nothing downstream works.
+
+2. **Record where you started**: `git branch --show-current`. Write it down. You will be
+   moved off this branch without warning (Step 5.7) and must return to it.
+
+3. **Map the worktrees**: `git worktree list`. Any branch checked out in another worktree
+   cannot be `gh pr checkout`'d, and may belong to a **live agent session**. This map
+   drives Step 5.1.
+
+4. **Read CLAUDE.md / AGENTS.md / project conventions** for:
+   - Local validation commands (`ci:local`, `test:verify`, etc.)
+   - Draft-vs-ready CI behavior, path filters, `ci:full` label semantics
+   - Merge-method policy (squash vs merge commit) and any forbidden patterns
+   - **Release/versioning rules** — see next item
+
+5. **Detect version-guard machinery.** Some repos fail CI unless every change bumps a
+   version, which forces PRs to merge *sequentially with distinct versions*. Look for:
+   - A versioning section in CLAUDE.md (search: `version`, `bump`, `propagat`)
+   - A bump script (`scripts/sync-version.sh`, `npm version`, `bumpversion`, …)
+   - A guard workflow in `.github/workflows/` that diffs versions against the base branch
+
+   **If found**: the queue is *stacked* — each PR needs its own version, assigned in Step 3.
+   **If not found**: skip all version-bump handling. Most repos don't have this. Do not
+   invent it.
+
+6. **Check auto-delete**: `gh repo view --json deleteBranchOnMerge`. If `false`, every
+   merge in this run risks leaving an orphan branch (Step 5.6). Note it for the report and
+   recommend flipping it — it fixes the failure mode permanently, including for web merges.
+
+### Step 1: Enumerate
+
+```bash
+gh pr list --state open --limit 100 \
+  --json number,title,author,isDraft,createdAt,headRefName,baseRefName,mergeable,labels
+```
+
+**Include drafts.** Draft status is frequently neglect rather than intent — the 2026-07-26
+run found all three drafts content-complete and merged them. Triage decides; enumeration
+does not pre-filter.
+
+If PR numbers were passed as arguments, restrict to those. Otherwise take everything.
+
+### Step 2: Triage Each PR
+
+This is the careful part. For each PR, gather:
+
+```bash
+gh pr view <N> --json title,body,isDraft,mergeable,mergeStateStatus,statusCheckRollup,\
+reviewDecision,author,headRefName,files,comments,reviews
+gh pr diff <N> --name-only
+```
+
+Assess, and **write down the reasoning** — it goes in the plan:
+
+- **What it actually changes.** Read the diff, not just the title. A PR whose description
+  and diff disagree is an ESCALATE.
+- **Is it complete?** Unfinished WIP, `TODO` markers, commented-out code, a description
+  promising work the diff doesn't contain. A draft that is complete is a MERGE candidate;
+  a non-draft that is incomplete is not.
+- **CI state.** Green / red / never ran. Red-on-one-known-check (e.g. a version guard that
+  every unbumped PR trips) is FIX-THEN-MERGE, not SKIP.
+- **Mergeability.** `CONFLICTING` means it needs a main merge in Step 5.2 — expected, not
+  disqualifying.
+- **Unresolved review threads.** Unaddressed review feedback is an ESCALATE. Merging past
+  a human's open question is not yours to do.
+- **Authorship.** Someone else's PR is an ESCALATE unless the user's invocation clearly
+  covers it (e.g. they said "merge all my PRs" and it's a bot's, or they named it).
+- **File overlap with other open PRs.** Record the overlapping paths — Step 3 needs them.
+
+Classify each as exactly one of:
+
+| Verdict | Meaning |
+|---|---|
+| **MERGE** | Complete, green or trivially fixable, no open questions |
+| **FIX-THEN-MERGE** | Needs a specific, named fix first (bump, main merge, lint) — state which |
+| **SKIP** | Not ready, with a reason the user can act on |
+| **ESCALATE** | Requires a decision you shouldn't make — surfaced in the plan, defaults to not merging |
+
+Every verdict carries a one-line reason. "Looks fine" is not a reason.
+
+### Step 3: Order the Queue
+
+Default: **oldest first** (by `createdAt`). Then apply two overrides:
+
+1. **File-overlap dependencies.** When two PRs touch the same paths, the one the other
+   builds on goes first — otherwise the second inherits a conflict you'll resolve blind.
+   If neither depends on the other, keep them adjacent so the conflict resolution is fresh
+   in context.
+2. **Small and green before large and red.** Early merges move `main` forward; cheap ones
+   first means later PRs rebase onto more settled ground.
+
+**If Step 0.5 found version-guard machinery**, assign each PR its own version now —
+sequential patch bumps from the current version, one per PR, in queue order. This is what
+makes a stacked queue mergeable: the guard can't be satisfied by a shared version number,
+and it keeps the CHANGELOG↔PR mapping 1:1.
+
+### Step 4: The Gate — Write and Present the Merge Plan
+
+**Write the plan to a file**, so a queue interrupted at PR 4 resumes instead of
+re-deriving. Default path: `docs/merge-plans/YYYY-MM-DD-merge-plan.md`.
+
+**The plan file must not dirty the working tree.** A dirty tree is one of two known
+triggers for `gh pr merge --delete-branch` half-failing and leaving the remote branch
+alive. So, after writing it:
+
+```bash
+mkdir -p .git/info
+grep -qxF 'docs/merge-plans/' .git/info/exclude 2>/dev/null || echo 'docs/merge-plans/' >> .git/info/exclude
+git status --porcelain    # MUST be empty before Step 5
+```
+
+`.git/info/exclude` is local and uncommitted, so this works in any repo without touching a
+shared `.gitignore`. If the user would rather commit the plan, commit it — either way the
+tree ends clean.
+
+The plan contains, per PR: number, title, verdict + reason, assigned version (if any),
+required fix (if FIX-THEN-MERGE), and a status column starting at `pending`.
+
+**Present it and stop.** Show the queue in order, the SKIP/ESCALATE list with reasons, and
+the version range. Ask once:
+
+> Approve this queue? I'll merge all N in order without further questions.
+
+Wait for approval. If the user amends the queue, update the file and re-present. **Nothing
+in Step 5 runs before explicit approval.**
+
+### Step 5: Execute the Queue
+
+For each PR in order. Every sub-step matters; the hazards below are all observed, not
+theoretical.
+
+**5.1 — Claim the branch safely.** If the Step 0.3 worktree map shows another worktree
+holds this branch, **do not disturb it** — it may be a live session. Verify it's clean and
+at the PR head (`git -C <path> status --short`), then work from a temp branch:
+
+```bash
+git fetch -q origin
+git checkout -b tmp/pr<N> origin/<headRefName>
+```
+
+Otherwise `gh pr checkout <N>` is fine.
+
+**5.2 — Bring in main.** `git merge origin/main`. Resolve conflicts yourself; you have the
+triage context. When resolving, prefer the narrowest correct resolution — the 2026-07-26
+run hit a conflict where a directory-level `git add -f docs/checkpoints/` would have
+force-committed everything the repo deliberately ignores; the fix was narrowing to the one
+explicit file.
+
+**5.3 — Version bump + CHANGELOG** (only if Step 0.5 found guard machinery). Use the
+repo's own script with this PR's assigned version, then add the matching CHANGELOG section.
+One version, one PR, one CHANGELOG entry.
+
+**5.4 — Validate locally, then push.** Run the project's local validation to exit 0 *before*
+pushing. Pushing an unvalidated commit burns a CI run and leaves the branch needing another
+fix — the worst square on the cost hierarchy. Then:
+
+```bash
+git push origin HEAD:<headRefName>     # works from temp branch or real branch alike
+```
+
+**5.5 — Drive CI to green.** Hand off to `/playbook:monitor-pr <N>`. It owns polling, cost
+discipline, failure triage, and the proof-of-completion comment. Do not duplicate it.
+
+**5.6 — Merge, then verify the branch actually died.**
+
+```bash
+gh pr merge <N> --squash --delete-branch     # match the repo's merge-method policy
+git fetch -q origin --prune
+git ls-remote --heads origin <headRefName> | wc -l    # MUST be 0
+```
+
+**Treat any non-empty error from `gh pr merge --delete-branch` as "the remote branch
+probably survived."** The merge succeeds, the local cleanup fails, and the operation
+deletes *neither* branch — but because the merge worked, the message reads as cosmetic.
+If the branch survived, finish it: `git push origin --delete <headRefName>`. Check with
+`git ls-remote` (authoritative), not `git branch -r` (stale local cache).
+
+**5.7 — Return to your branch.** `gh pr merge --delete-branch` silently checks out the
+default branch and pulls. In a parallel-agent workspace this strands the session. Re-checkout
+the Step 0.2 branch, and delete `tmp/pr<N>` if you made one.
+
+**5.8 — Tick it off.** Update the plan file: status `merged`, record the new `main` SHA.
+This is what makes the run resumable.
+
+### Step 6: Exceptions — Skip, Don't Halt
+
+A PR that breaks its triage assumptions mid-run (a new conflict, someone pushed to it, CI
+red for a reason `monitor-pr` can't fix, local validation that won't go green) is
+**skipped, not halted on**. Mark it `skipped` in the plan with what happened, and continue
+to the next PR. The remaining PRs are independent and already approved; forfeiting them
+because one went bad is the failure mode this step exists to prevent.
+
+**Stop the whole queue only for**:
+
+- `gh` auth loss or repo-level permission failure — nothing further will work
+- A merge that lands broken code on `main` (post-merge CI on `main` goes red) — fix or
+  revert that before merging anything else onto a broken base
+- Evidence another agent or human is actively pushing to `main` mid-run
+- Three consecutive PRs failing for unrelated reasons — the plan's assumptions are stale;
+  re-triage rather than grinding through
+
+### Step 7: Final Report
+
+- **Merged**: number, title, version, merge commit
+- **Skipped**: number + what happened + what would unblock it
+- **Escalated**: the decisions that were never yours to make
+- **Final state**: `main` SHA, final version, open-PR count (should be the escalated +
+  skipped set)
+- **Leftovers**: any remote branch that survived its merge, any `tmp/pr*` still around
+- **Repo hygiene**: if `deleteBranchOnMerge` was `false`, say so and recommend flipping it
+
+## Anti-Patterns (Don't Do These)
+
+- **Re-asking after Step 4.** The gate was the deal. Skip and report instead.
+- **Halting the queue on one bad PR.** Step 6 exists for this.
+- **Reimplementing `monitor-pr`.** CI polling, failure triage, and the proof-of-completion
+  comment live there.
+- **Assuming `--delete-branch` worked.** Verify with `git ls-remote`, every time.
+- **Touching another worktree's checkout.** Read it, never write it.
+- **Inventing version bumps** in a repo with no version guard.
+- **Merging past an unresolved review thread.** That's an ESCALATE, always.
+- **Pushing before local validation passes.** Burns CI minutes and compounds the fix.
+- **Force-adding directories** during conflict resolution. Name the file.
+
+## When to Escalate to the User
+
+Surface in the plan (Step 4) rather than deciding yourself:
+
+- PRs authored by someone else
+- Unresolved review threads
+- A PR whose description and diff disagree
+- A PR that would revert or supersede another open PR
+- Anything touching auth, secrets, payments, migrations, or production config
+
+## After Completion
+
+Suggest `/playbook:learnings` if the run surfaced anything new about the repo's merge
+mechanics, and `/playbook:close` if this was the session's main work.
+
+## Usage Pattern
+
+```
+/playbook:merge-prs              # triage everything, one plan, one approval
+/playbook:merge-prs 57 58 61     # limit the queue to these PRs
+```
+
+Pairs with `/playbook:monitor-pr` (single PR) — use that when you have one PR to shepherd,
+this when you have a backlog.

--- a/scripts/validate-plugin.sh
+++ b/scripts/validate-plugin.sh
@@ -312,6 +312,97 @@ fi
 
 echo ""
 
+# 9. Command surface coverage (commands/help.md + README.md)
+# WHY: help.md and README.md hand-duplicate data that already lives in every command's
+# frontmatter, and adding a command has no step that touches either file. They drift by
+# omission — six real commands (close, close-project, emergent, foundations, monitor-pr,
+# research-synthesis) went missing from help.md before this check existed, which makes a
+# command effectively undiscoverable no matter how good it is. Generating these files was
+# rejected: their value is the human judgment about WHICH command fits WHICH situation,
+# which no frontmatter field encodes. So enforce coverage and leave the curation alone.
+# Bidirectional, because both directions fail: a new command going unlisted (observed),
+# and a renamed/deleted command leaving a dangling reference (not yet, but inevitable).
+echo "Checking command surface coverage (help.md + README.md)..."
+echo "-------------------------------------------"
+
+# NOTE: the report goes to a temp file rather than through $(...). bash 3.2 (still the
+# default /bin/bash on macOS) mis-parses a heredoc containing apostrophes when it sits
+# inside command substitution, failing with "unexpected EOF while looking for matching `'".
+COVERAGE_TMP="$(mktemp)"
+trap 'rm -f "$COVERAGE_TMP"' EXIT
+
+python3 - "$PLUGIN_DIR" > "$COVERAGE_TMP" <<'PY'
+import os, re, sys
+
+plugin_dir = sys.argv[1]
+cmd_dir = os.path.join(plugin_dir, "commands")
+help_rel = "commands/help.md"
+help_path = os.path.join(plugin_dir, help_rel)
+readme_path = "README.md"
+
+# Every command's declared name, from frontmatter (the filename may differ: e.g.
+# commands/git/create-pr.md declares playbook:git-pr).
+real = {}
+for root, _, files in os.walk(cmd_dir):
+    for fn in sorted(files):
+        if not fn.endswith(".md"):
+            continue
+        path = os.path.join(root, fn)
+        with open(path) as f:
+            for line in f:
+                m = re.match(r'^name:\s*(\S+)', line)
+                if m:
+                    real[m.group(1)] = os.path.relpath(path, plugin_dir)
+                    break
+
+if not real:
+    print("ERR||no commands with a 'name:' field found")
+
+if os.path.isfile(help_path):
+    with open(help_path) as f:
+        help_txt = f.read()
+    problems = 0
+    for name, src in sorted(real.items()):
+        # Trailing (?![\w-]) so /playbook:work is not satisfied by /playbook:work-multiple.
+        if not re.search(r'/' + re.escape(name) + r'(?![\w-])', help_txt):
+            print(f"ERR|{name}|not listed in {help_rel} (defined in {src})")
+            problems += 1
+    for ref in sorted(set(re.findall(r'/(playbook:[a-z0-9][a-z0-9-]*)', help_txt))):
+        if ref not in real:
+            print(f"ERR|{ref}|referenced in {help_rel} but no command defines it")
+            problems += 1
+    if not problems:
+        print(f"OK||{help_rel} covers all {len(real)} commands, no dangling references")
+else:
+    print(f"ERR||{help_rel} not found")
+
+if os.path.isfile(readme_path):
+    with open(readme_path) as f:
+        readme_txt = f.read()
+    # Require a real table row, not a prose mention: /playbook:close-project was named in
+    # README prose while absent from every command table.
+    problems = 0
+    for name, src in sorted(real.items()):
+        if not re.search(r'^\|\s*`/' + re.escape(name) + r'`\s*\|', readme_txt, re.M):
+            print(f"ERR|{name}|no README.md command-table row (defined in {src})")
+            problems += 1
+    if not problems:
+        print(f"OK||README.md has a table row for all {len(real)} commands")
+else:
+    print("WARN||README.md not found - skipping README coverage")
+PY
+
+while IFS='|' read -r status name detail; do
+    [ -z "$status" ] && continue
+    case "$status" in
+        OK)   success "$detail" ;;
+        WARN) warning "$detail" ;;
+        ERR)  if [ -n "$name" ]; then error "$name: $detail"; else error "$detail"; fi ;;
+    esac
+done < "$COVERAGE_TMP"
+
+echo ""
+
 # Summary
 echo "=========================================="
 echo "Validation Summary"


### PR DESCRIPTION
## What ships

**1. `/playbook:merge-prs`** — clears an open-PR backlog with a single approval gate.

The capability had been exercised twice by hand (4 PRs in 2026-07-17, 9 PRs in 2026-07-26), with the procedure split across three places that nothing composed: `/playbook:monitor-pr` owned per-PR merge mechanics, CLAUDE.md held the stacked-bump ordering as prose, and `docs/learnings/2026-07-17-merging-stacked-prs-across-worktrees.md` held the evidence. Every run re-derived the orchestration.

Flow: enumerate every open PR (including drafts — draft status is frequently neglect rather than intent, as the 2026-07-26 run found) → triage each into **MERGE / FIX-THEN-MERGE / SKIP / ESCALATE** with a stated reason → order the queue → **write a merge plan and get one approval** → run the queue unattended.

**2. Command-surface coverage enforcement** — six real commands (`close`, `close-project`, `emergent`, `foundations`, `monitor-pr`, `research-synthesis`) were missing from `commands/help.md`; four were missing from README's tables.

## Why the autonomy envelope is "one gate up front"

All the expensive judgment lives in triage — is this draft complete? does this PR ship without the WIP it references? whose branch is this? Everything after is mechanical and long-running. Per-PR gating would re-interrupt for decisions already made; full autonomy would remove the one step where human judgment genuinely mattered.

## Design points carried over from the hand-run sessions

- **Skip, don't halt.** A PR that breaks its triage assumptions mid-run is skipped and reported; the rest of the approved queue still merges. Forfeiting eight good merges because the fourth developed a conflict is the failure mode this prevents.
- **The plan file must not dirty the working tree.** A dirty tree is one of two documented triggers for `gh pr merge --delete-branch` half-failing and leaving the remote branch alive (monitor-pr Step 4, corrected 2026-07-26). The plan goes to `docs/merge-plans/` with the path added to `.git/info/exclude` — local, uncommitted, works in any git repo — and Step 5 asserts a clean tree before each merge.
- **Version-guard machinery is detected, not assumed.** Sequential stacked bumps are specific to repos with a version guard. The command looks for one and skips the entire layer when absent, so it works in any repo.
- Worktree-aware branch claiming; branch deletion verified via `git ls-remote` rather than assumed.

It delegates per-PR CI work to `/playbook:monitor-pr` (which delegates failure analysis to `/playbook:debug-ci`) rather than reimplementing either.

## Root cause of the help.md drift

Both help.md and README hand-duplicate data that already lives in each command's frontmatter, and adding a command has no step that touches either file. `validate-plugin.sh` now enforces coverage **bidirectionally**: every command must appear in help.md and as a README table row, and every `/playbook:x` referenced in help.md must resolve to a real command. `plugin-guard.yml` already runs that script on every PR, so an unlisted command is now unmergeable — including `/playbook:merge-prs` itself, so the two halves of this PR validate each other.

**Generating help.md from frontmatter was considered and rejected.** It would need a `category:` field on all 40 commands, and the valuable part of help.md is the human judgment about *which* command fits *which* situation plus the workflow recipes — none of which any frontmatter field encodes. A generator would either destroy that or become a template-with-holes. Enforce coverage, leave the curation alone.

Three implementation notes worth flagging for review:
- The README check requires a **table row**, not a prose mention — `close-project` was named in README prose while absent from every table.
- The help.md check uses a `(?![\w-])` lookahead so `/playbook:work` isn't considered covered by `/playbook:work-multiple`.
- The coverage report goes to a temp file rather than through `$(...)`: bash 3.2 (still macOS's default `/bin/bash`) mis-parses a heredoc containing apostrophes inside command substitution, which failed with `unexpected EOF while looking for matching '`.

## Verification

- `scripts/validate-plugin.sh` — **PASSED**, 0 errors / 0 warnings (40 commands, 9 agents, 10 skills, 18 templates)
- `scripts/check-version-bump.sh origin/main` — **PASSED**, `0.25.2 -> 0.26.0`
- New check verified in **both** failure directions: it listed exactly the 14 known gaps before the content fix, and flagged an injected phantom `/playbook:this-does-not-exist` as a dangling reference
- Prefix-collision guard verified directly: `/playbook:work-multiple` does not satisfy `/playbook:work`

`/playbook:merge-prs` itself has **not** been executed end-to-end against a live backlog — there are currently no other open PRs to run it against. Its constituent mechanics are all inherited from `/playbook:monitor-pr`, which is proven, but the orchestration layer is unexercised. First real run is the test.

## Design doc

`docs/superpowers/specs/2026-08-04-merge-prs-and-help-coverage-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)