### PR TITLE
fix(merge-prs): resolve info/exclude via --git-common-dir, not .git/info (0.26.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "product-playbook-for-agentic-coding",
       "source": "./plugins/product-playbook-for-agentic-coding",
       "description": "A structured 4-phase workflow for agentic coding",
-      "version": "0.26.0"
+      "version": "0.26.1"
     },
     {
       "name": "openai-image-gen",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.1] - 2026-08-04
+
+### Fixed
+- **`/playbook:merge-prs` Step 4: `.git/info/exclude` fails inside a git worktree** — The
+  snippet ran `mkdir -p .git/info`, which assumes `.git` is a directory. In a worktree
+  (Conductor workspaces, `git worktree add`) `.git` is a **file** containing a `gitdir:`
+  pointer, so the command aborts with `Not a directory` and the plan file is never excluded
+  — leaving the working tree dirty, which is itself one of the two triggers for
+  `gh pr merge --delete-branch` half-failing.
+
+  Now resolves the path with `git rev-parse --git-common-dir` and verifies with
+  `git check-ignore`. Common-dir rather than `--git-dir` because `info/exclude` lives in the
+  common directory, shared across worktrees — which is also where git actually reads it from.
+
+  Found on the command's first real run, in exactly the environment it was written for.
+
 ## [0.26.0] - 2026-08-04
 
 ### Added

--- a/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
+++ b/plugins/product-playbook-for-agentic-coding/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "product-playbook-for-agentic-coding",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "A structured 4-phase workflow for agentic coding: Product Discovery, Solution Planning, Delivery, and Retrospective. Provides commands, agents, and skills for systematic software development with AI.",
   "author": {
     "name": "Davis Whitehead",

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/merge-prs.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/merge-prs.md
@@ -151,14 +151,19 @@ triggers for `gh pr merge --delete-branch` half-failing and leaving the remote b
 alive. So, after writing it:
 
 ```bash
-mkdir -p .git/info
-grep -qxF 'docs/merge-plans/' .git/info/exclude 2>/dev/null || echo 'docs/merge-plans/' >> .git/info/exclude
+# NOT ".git/info/exclude" — in a git worktree (Conductor, `git worktree add`) .git is a
+# FILE pointing at the real gitdir, so that path fails with "Not a directory". Ask git.
+EXCLUDE="$(git rev-parse --git-common-dir)/info/exclude"
+mkdir -p "$(dirname "$EXCLUDE")"
+grep -qxF 'docs/merge-plans/' "$EXCLUDE" 2>/dev/null || echo 'docs/merge-plans/' >> "$EXCLUDE"
+git check-ignore -q docs/merge-plans/ && echo "excluded OK"
 git status --porcelain    # MUST be empty before Step 5
 ```
 
-`.git/info/exclude` is local and uncommitted, so this works in any repo without touching a
-shared `.gitignore`. If the user would rather commit the plan, commit it — either way the
-tree ends clean.
+`info/exclude` is local and uncommitted, so this works in any repo without touching a
+shared `.gitignore`. Use `--git-common-dir`, not `--git-dir`: `info/exclude` lives in the
+common directory and is shared across all worktrees, which is also what git actually reads.
+If the user would rather commit the plan, commit it — either way the tree ends clean.
 
 The plan contains, per PR: number, title, verdict + reason, assigned version (if any),
 required fix (if FIX-THEN-MERGE), and a status column starting at `pending`.


### PR DESCRIPTION
Found on `/playbook:merge-prs`'s **first real run**, in exactly the environment it was written for.

## The bug

Step 4 wrote the merge plan, then ran:

```bash
mkdir -p .git/info
grep -qxF 'docs/merge-plans/' .git/info/exclude || echo 'docs/merge-plans/' >> .git/info/exclude
```

That assumes `.git` is a directory. Inside a **git worktree** — Conductor workspaces, `git worktree add` — `.git` is a *file* containing a `gitdir:` pointer:

```
mkdir: .git: Not a directory
```

## Why it mattered

The whole point of that snippet is keeping the plan file from dirtying the working tree, because **a dirty tree is one of the two documented triggers for `gh pr merge --delete-branch` half-failing** and leaving the remote branch alive (`monitor-pr` Step 4, corrected 2026-07-26). So the failure mode was: the guard against a known hazard silently didn't arm, in the parallel-agent workspaces the command explicitly targets.

## Fix

Ask git for the path instead of assuming it, and verify the result:

```bash
EXCLUDE="$(git rev-parse --git-common-dir)/info/exclude"
mkdir -p "$(dirname "$EXCLUDE")"
grep -qxF 'docs/merge-plans/' "$EXCLUDE" 2>/dev/null || echo 'docs/merge-plans/' >> "$EXCLUDE"
git check-ignore -q docs/merge-plans/ && echo "excluded OK"
```

`--git-common-dir`, not `--git-dir`: `info/exclude` lives in the common directory and is shared across worktrees, which is also where git actually reads it from. In this workspace `--git-dir` resolves to `.git/worktrees/praia` while `--git-common-dir` resolves to `.git` — only the latter is consulted for excludes.

## Verification

- Reproduced the failure, applied the fix, confirmed `git check-ignore -v docs/merge-plans/.probe` now resolves to `.git/info/exclude:10`
- `scripts/validate-plugin.sh` — PASSED, 0 errors / 0 warnings
- `scripts/check-version-bump.sh origin/main` — PASSED, `0.26.0 -> 0.26.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)