### PR TITLE
fix(release): move version bumps out of PRs onto main via changesets

### DIFF
--- a/.changes/README.md
+++ b/.changes/README.md
@@ -1,0 +1,61 @@
+# Changesets
+
+A **changeset** is one file describing one change: which plugin it touches, how big the
+version bump should be, and the CHANGELOG prose. PRs add a changeset instead of editing
+the version.
+
+## Why this exists
+
+The version is a single monotonic counter on `main`, but PRs are parallel. When every PR
+had to bump the version itself, N open PRs could not all be correct at once — they would
+all claim the same next number — so merges had to serialize, one patch version per PR, and
+each PR's version-file edits conflicted with every other PR's.
+
+Worse, that conflict was doing load-bearing safety work nobody designed: `check-version-bump.sh`
+compares against the **merge base**, so it verifies "this branch bumped since it forked,"
+not "main's version will increase." A branch forked at 0.26.1 bumping to 0.26.2 passed the
+guard even when `main` had already reached 0.26.4. The only thing stopping that merge from
+dragging main's version *backwards* was git conflicting on the version lines — the same
+friction everyone was trying to get rid of.
+
+A changeset is a **new file per PR**, so it cannot conflict. Any number of PRs merge in any
+order. The version is computed once, on `main`, by `scripts/release.sh`.
+
+## Writing one
+
+Create `.changes/<short-slug>.md`:
+
+```markdown
+---
+plugin: product-playbook-for-agentic-coding
+bump: patch
+---
+
+### Fixed
+- **What changed** — why it mattered, and what it prevents now.
+```
+
+- `plugin` — directory name under `plugins/`. Defaults to `product-playbook-for-agentic-coding`.
+- `bump` — `patch` | `minor` | `major`, per CLAUDE.md's rules (MINOR for new commands/agents/skills,
+  PATCH for fixes and doc updates, MAJOR for breaking changes).
+- Body — goes into CHANGELOG.md verbatim, under its `###` heading. Write it for the person
+  who will read it in six months, not for the diff.
+
+The slug is only a filename; anything unique works. `pr-<number>` or a short description
+both read fine.
+
+## Releasing
+
+After merging (one release covers any number of merged PRs):
+
+```bash
+scripts/release.sh          # consumes .changes/*, bumps, writes CHANGELOG, deletes changesets
+git add -A && git commit -m "chore: release <version>" && git push
+```
+
+`scripts/release.sh --dry-run` shows what it would do without touching anything.
+
+Between a merge and the release, CI on `main` fails with "unreleased changesets" — that is
+the forcing function. Propagation is version-keyed, so content sitting on `main` at an
+unchanged version has not reached a single user's install; a red main is the loud version
+of a problem that used to be silent.

--- a/.changes/version-bump-changesets.md
+++ b/.changes/version-bump-changesets.md
@@ -1,0 +1,45 @@
+---
+plugin: product-playbook-for-agentic-coding
+bump: minor
+---
+
+### Changed
+- **Version bumps move out of PRs and onto `main` (changesets)** — PRs now add a file under
+  `.changes/` declaring `bump: patch|minor|major` plus its CHANGELOG prose, instead of editing
+  the version. `scripts/release.sh` consumes those files on `main`, computes each plugin's new
+  version (highest bump type wins), updates `plugin.json` + `marketplace.json` + `CHANGELOG.md`,
+  and deletes the changesets.
+
+  **Root cause this fixes.** The version is a single monotonic counter on `main`, but PRs are
+  parallel writers. Requiring each PR to advance it made N open PRs mutually exclusive — they
+  all wanted the same next number — which forced serialized merges (one patch version per PR:
+  0.22.1→0.22.4 in 2026-07, 0.23.0→0.24.3 across nine PRs in 2026-07-26, 0.26.1→0.26.4 today)
+  and made every PR's version-file edits conflict with every other PR's. A changeset is a new
+  file, so it cannot conflict; merge order is free and one release covers the whole batch.
+
+### Fixed
+- **`check-version-bump.sh` was checking the wrong thing, and its `main` run could never fail** —
+  It compared the working tree against the **merge base**, which verifies "this branch bumped
+  since it forked", not "main's version will increase". A branch forked at 0.26.1 and bumped to
+  0.26.2 passed the guard even when `main` had already reached 0.26.4 — and merging it would drag
+  the version *backwards*, the exact failure the guard's own comments warn about. The only thing
+  preventing that was git conflicting on the version lines, i.e. the friction above was doing
+  load-bearing safety work nobody designed. Separately, the push-to-`main` invocation compared
+  `main` against itself, always reported "unchanged", and could not fail under any input, so
+  there was no post-merge backstop at all.
+
+  The script now has two modes. **PR**: the changed plugin must declare a changeset (a hand bump
+  is still accepted, with a nudge). **main**: fails while changesets sit unreleased, and fails if
+  plugin content changed without the version increasing versus the previous commit — a real
+  backstop that catches a duplicate or backwards version however it arrived.
+
+### Added
+- **`scripts/test-version-checks.sh`** — 20 cases across both scripts in a sandbox repo,
+  including the two the old guard was structurally blind to: content merged at an unchanged
+  version, and a version moving backwards on `main`.
+- **`/playbook:merge-prs` distinguishes the two release styles** — Step 0.5 now classifies a repo
+  as changeset-style or bump-in-PR style. Changeset repos skip per-PR version assignment entirely
+  and run a single release after the queue drains (new Step 5.9); bump-in-PR repos keep the
+  stacked behaviour and get told in the final report that changesets are the fix. Step 5.6 also
+  learned that server-side branch auto-delete is asynchronous, so a branch that looks like it
+  survived should be re-checked once before deleting by hand.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,48 +13,83 @@ This bit us once already: a content-only commit shipped at the same version, and
 every local install silently stayed on the old copy. The guardrails below make that
 mistake impossible to merge.
 
-**IMPORTANT**: Every change to a plugin MUST bump its version in **both** files, which
-must always match:
-
-1. **`plugins/<plugin-name>/.claude-plugin/plugin.json`** — the plugin's own version
-2. **`.claude-plugin/marketplace.json`** — the marketplace entry's `version`
-
-Do the bump with the helper (it edits both together so they can't drift):
+**IMPORTANT**: Every change to a plugin MUST declare a version change. **Do not edit the
+version in a PR** — add a **changeset** instead:
 
 ```bash
-scripts/sync-version.sh <new-version>          # e.g. 0.22.0
-# then add a "## [<new-version>] - YYYY-MM-DD" section to CHANGELOG.md
+cat > .changes/my-change.md <<'EOF'
+---
+plugin: product-playbook-for-agentic-coding
+bump: patch
+---
+
+### Fixed
+- **What changed** — why it mattered, and what it prevents now.
+EOF
+```
+
+A changeset is a new file, so it can never conflict with another PR. The version itself is
+computed once, on `main`:
+
+```bash
+scripts/release.sh          # consumes .changes/*, bumps both manifests, writes CHANGELOG
+git add -A && git commit -m "chore: release" && git push
 ```
 
 Also update **`README.md`** if component counts/tables changed.
 
+### Why not bump in the PR?
+
+The version is a single monotonic counter on `main`, but PRs are parallel. Requiring each
+PR to bump it made N open PRs mutually exclusive — they all wanted the same next number —
+so merges had to serialize, one patch version per PR, with every PR's version-file edits
+conflicting with every other PR's.
+
+And that conflict was doing load-bearing safety work nobody designed. The guard compared
+against the **merge base**, so it verified "this branch bumped since it forked", not
+"main's version will increase": a branch forked at 0.26.1 and bumped to 0.26.2 passed even
+when `main` had already reached 0.26.4. The only thing preventing that merge from dragging
+main's version *backwards* was git conflicting on the version lines. Meanwhile the
+main-branch guard run compared main against itself, so it always reported "unchanged" and
+could never fail — there was no post-merge backstop at all.
+
+Changesets remove the shared-counter contention; the rewritten guard supplies the backstop
+that was missing. See `.changes/README.md`.
+
 ### Version Bumping Rules
+
+Set `bump:` in the changeset accordingly:
 
 - **MAJOR** (1.0.0 → 2.0.0): Breaking changes, major reorganization
 - **MINOR** (1.0.0 → 1.1.0): New commands, agents, or skills
 - **PATCH** (1.0.0 → 1.0.1): Bug fixes, doc updates, minor improvements
 
+When several changesets are released together, the **highest** bump type wins.
+
 ### Enforcement
 
-Two guards run on every PR to `main` (`.github/workflows/plugin-guard.yml`), and you
-can run them locally:
+Guards run on every PR to `main` and on every push to `main`
+(`.github/workflows/plugin-guard.yml`), and you can run them locally:
 
-- `scripts/validate-plugin.sh` — asserts each `marketplace.json` entry's version
-  matches the corresponding `plugin.json` version.
-- `scripts/check-version-bump.sh [base-ref]` — fails if any plugin's files changed
-  versus the base branch without a `plugin.json` version bump.
+- `scripts/validate-plugin.sh` — asserts each `marketplace.json` entry's version matches
+  the corresponding `plugin.json` version, and that every command appears in `help.md` and
+  README's tables.
+- `scripts/check-version-bump.sh [base-ref]` — two modes. On a **PR**: the changed plugin
+  must declare a changeset (a hand bump is still accepted). On **main**: fails while
+  changesets sit unreleased, and fails if plugin content changed without the version
+  increasing versus the previous commit.
+- `scripts/test-version-checks.sh` — 20 cases over both scripts. Run it after touching
+  either.
 
-### Merging multiple open PRs (stacked bumps)
+### Merging multiple open PRs
 
-When several content PRs are open at once, none will pass the guard until each
-bumps the version — and they can't all claim the same number. Merge them
-**sequentially, oldest first, one patch version per PR**: check out the PR
-branch (if another worktree holds it, use a temp branch + `git push origin
-HEAD:<branch>`), merge `origin/main` in, run `scripts/sync-version.sh
-<next-patch>`, add the CHANGELOG section, push, wait for the guard, merge, then
-repeat for the next PR against the new main. This keeps CHANGELOG↔PR mapping
-1:1 and lets every merge pass the guard independently. (Proven on the 2026-07
-four-PR backlog: 0.22.1 → 0.22.4.)
+Merge them in any order — changesets don't conflict, so nothing needs to be stacked. Then
+run `scripts/release.sh` **once** and push; that single release covers every PR merged
+since the last one. `main` is red between the first merge and the release, which is the
+forcing function: content on `main` at an unchanged version has reached zero installs.
+
+If another worktree holds a PR branch, don't disturb it — use a temp branch plus
+`git push origin HEAD:<branch>`. `/playbook:merge-prs` automates this whole flow.
 
 ### Delivering an update to installed machines
 
@@ -221,10 +256,10 @@ Two output targets:
 
 Before committing changes:
 
-- [ ] Version bumped in **both** `plugin.json` and `marketplace.json` (use `scripts/sync-version.sh`)
-- [ ] `CHANGELOG.md` has a section for the new version
-- [ ] `scripts/validate-plugin.sh` passes (incl. version consistency)
-- [ ] `scripts/check-version-bump.sh` passes (plugin changed ⇒ version bumped)
+- [ ] Changeset added under `.changes/` (do **not** hand-edit the version in a PR)
+- [ ] Changeset body is the CHANGELOG prose you actually want (`release.sh` uses it verbatim)
+- [ ] `scripts/validate-plugin.sh` passes (incl. version + command-surface coverage)
+- [ ] `scripts/check-version-bump.sh` passes (plugin changed ⇒ change declared)
 - [ ] README.md updated if components changed
 - [ ] All commands have proper frontmatter (name, description)
 - [ ] All agents have proper frontmatter (name, description, model)

--- a/README.md
+++ b/README.md
@@ -200,8 +200,21 @@ Some things shouldn't depend on an agent remembering to do them. These run in th
 |---|---|---|
 | `hooks/hooks.json` → `scripts/session-orientation.sh` | `SessionStart` hook | Gathers branch/tracking state, uncommitted count, active `projects/in-progress/` dirs, latest checkpoint, last 3 commits, and stashes tagged to this branch — with no tool round-trips. Silent outside a git repo or in a repo without the playbook layout. Opt out with `PLAYBOOK_NO_ORIENTATION=1`. |
 | `scripts/verify-close-project.sh <name>` | Executable check | Asserts a close-out actually completed — above all that the **source directory is gone**, not merely that `done/` exists. |
+| `scripts/check-version-bump.sh` | CI guard (PR + push) | On a PR: the changed plugin must declare a changeset. On `main`: fails while changesets sit unreleased, and fails if plugin content changed without the version increasing. |
+| `scripts/release.sh` | Release step | Consumes `.changes/*`, computes each plugin's new version, updates both manifests + `CHANGELOG.md`, deletes the changesets. `--dry-run` to preview. |
 
-Run `scripts/test-close-project-checks.sh` after changing either (14 cases, both directions).
+Run `scripts/test-close-project-checks.sh` after changing either close-project piece (14
+cases, both directions), and `scripts/test-version-checks.sh` after touching the version
+scripts (20 cases across both).
+
+**Why changesets**: the version is a single monotonic counter on `main`, but PRs are
+parallel. Requiring each PR to bump it made N open PRs mutually exclusive — they all wanted
+the same next number — forcing serialized merges and pairwise conflicts on the version
+lines. Worse, the guard compared against the *merge base*, so it checked "did this branch
+bump since it forked", not "will main's version increase"; the only thing preventing a
+stale PR from dragging the version backwards was that very conflict. A changeset is a new
+file per PR, so it cannot conflict, and the number is computed once on `main`. See
+`.changes/README.md`.
 
 **Why these are scripts rather than instructions**: `/playbook:close-project`'s checklist asked *"Project lives under `projects/done/`?"* — which was **true** while `forgot-password` and `illustration-batch` sat duplicated in both `in-progress/` and `done/` for ~3.7 months. The agent answering a checklist is the same one that just performed the move. A real guardrail has to be deterministic.
 

--- a/plugins/product-playbook-for-agentic-coding/commands/workflows/merge-prs.md
+++ b/plugins/product-playbook-for-agentic-coding/commands/workflows/merge-prs.md
@@ -60,15 +60,25 @@ is Step 6's escalation list — genuinely unsafe territory, where stopping is co
    - Merge-method policy (squash vs merge commit) and any forbidden patterns
    - **Release/versioning rules** — see next item
 
-5. **Detect version-guard machinery.** Some repos fail CI unless every change bumps a
-   version, which forces PRs to merge *sequentially with distinct versions*. Look for:
-   - A versioning section in CLAUDE.md (search: `version`, `bump`, `propagat`)
-   - A bump script (`scripts/sync-version.sh`, `npm version`, `bumpversion`, …)
-   - A guard workflow in `.github/workflows/` that diffs versions against the base branch
+5. **Detect release machinery, and which of two kinds it is.** Some repos fail CI unless
+   every change declares a version change. Look for a versioning section in CLAUDE.md
+   (search: `version`, `bump`, `changeset`, `propagat`), a release or bump script, and a
+   guard workflow in `.github/workflows/`. Then classify:
 
-   **If found**: the queue is *stacked* — each PR needs its own version, assigned in Step 3.
-   **If not found**: skip all version-bump handling. Most repos don't have this. Do not
-   invent it.
+   **(a) Changeset-style** — `.changes/`, `.changeset/`, `changie`, or a `release.sh` that
+   consumes declaration files. **Strongly preferred, and the queue is trivial**: each PR
+   declares a bump in its own new file, so nothing conflicts and merge order is free. Do
+   **not** assign per-PR versions. Merge everything, then run the release **once** at the
+   end (Step 5.9).
+
+   **(b) Bump-in-PR style** — the version is edited directly in a manifest and a guard
+   diffs it against the base branch. The queue is *stacked*: each PR needs its own version,
+   assigned in Step 3, and merges must serialize. This is the painful path — the version is
+   a serial counter on the default branch and PRs are parallel writers, so N open PRs all
+   want the same next number and their manifest edits conflict pairwise. If you find this,
+   run the queue, then **say so in the final report** and point at changesets as the fix.
+
+   **If neither**: skip all version handling. Most repos have none. Do not invent it.
 
 6. **Check auto-delete**: `gh repo view --json deleteBranchOnMerge`. If `false`, every
    merge in this run risks leaving an orphan branch (Step 5.6). Note it for the report and
@@ -136,10 +146,13 @@ Default: **oldest first** (by `createdAt`). Then apply two overrides:
 2. **Small and green before large and red.** Early merges move `main` forward; cheap ones
    first means later PRs rebase onto more settled ground.
 
-**If Step 0.5 found version-guard machinery**, assign each PR its own version now —
+**If Step 0.5 found bump-in-PR machinery (b)**, assign each PR its own version now —
 sequential patch bumps from the current version, one per PR, in queue order. This is what
 makes a stacked queue mergeable: the guard can't be satisfied by a shared version number,
 and it keeps the CHANGELOG↔PR mapping 1:1.
+
+**If it found changeset-style machinery (a)**, assign nothing. Versions are computed once
+at Step 5.9, and ordering only matters for the file-overlap reasons above.
 
 ### Step 4: The Gate — Write and Present the Merge Plan
 
@@ -198,9 +211,13 @@ run hit a conflict where a directory-level `git add -f docs/checkpoints/` would 
 force-committed everything the repo deliberately ignores; the fix was narrowing to the one
 explicit file.
 
-**5.3 — Version bump + CHANGELOG** (only if Step 0.5 found guard machinery). Use the
-repo's own script with this PR's assigned version, then add the matching CHANGELOG section.
-One version, one PR, one CHANGELOG entry.
+**5.3 — Declare the version change** (only if Step 0.5 found release machinery).
+
+- **Changeset-style (a)**: confirm the PR carries a changeset; add one if it doesn't. Never
+  edit the version manifest here — that reintroduces the conflicts changesets exist to
+  remove.
+- **Bump-in-PR style (b)**: run the repo's bump script with this PR's assigned version, then
+  add the matching CHANGELOG section. One version, one PR, one CHANGELOG entry.
 
 **5.4 — Validate locally, then push.** Run the project's local validation to exit 0 *before*
 pushing. Pushing an unvalidated commit burns a CI run and leaves the branch needing another
@@ -233,6 +250,25 @@ the Step 0.2 branch, and delete `tmp/pr<N>` if you made one.
 
 **5.8 — Tick it off.** Update the plan file: status `merged`, record the new `main` SHA.
 This is what makes the run resumable.
+
+**5.9 — Release once, after the queue drains** (changeset-style repos only). Run the repo's
+release script on an up-to-date default branch, then commit and push it:
+
+```bash
+git checkout main && git pull
+scripts/release.sh          # or the repo's equivalent
+git add -A && git commit -m "chore: release <version>" && git push
+```
+
+One release covers every PR merged in this run. Expect the default branch's CI to be **red
+between the first merge and this step** — that is the intended forcing function, not a
+failure to investigate: merged content sitting at an unchanged version has reached zero
+installs. Verify CI goes green after the release push, and report the released version.
+
+**5.6 already ran per PR** — a branch delete that reports success can still be asynchronous.
+If `git ls-remote` says the branch survived, re-check once after a few seconds before
+deleting by hand; server-side auto-delete (`deleteBranchOnMerge`) commonly lands a beat late
+and produces a false "it survived."
 
 ### Step 6: Exceptions — Skip, Don't Halt
 

--- a/scripts/check-version-bump.sh
+++ b/scripts/check-version-bump.sh
@@ -1,27 +1,39 @@
 #!/bin/bash
 #
-# check-version-bump.sh — Fail if a plugin's files changed without a version bump.
+# check-version-bump.sh — Enforce that plugin changes actually propagate to installs.
 #
 # WHY THIS EXISTS:
-#   Claude Code marketplace auto-update is *version-keyed*: a plugin only re-installs
-#   on users' machines when its version number changes. So a content change shipped
-#   at an unchanged version silently never propagates — installs stay stale forever.
-#   This check makes that mistake impossible to merge: if any tracked file under a
-#   plugin directory differs from the base branch, that plugin's plugin.json version
-#   MUST also differ.
+#   Claude Code marketplace auto-update is *version-keyed*: a plugin only re-installs on
+#   users' machines when its version number changes. A content change shipped at an
+#   unchanged version silently never propagates — installs stay stale forever.
+#
+# TWO MODES, because the question is different before and after a merge:
+#
+#   PR MODE  (HEAD != base tip). "Does this PR declare a version change?"
+#     Satisfied by a changeset under .changes/ (preferred — a new file per PR, so it
+#     cannot conflict with any other PR) or by a hand bump of plugin.json (legacy path,
+#     still accepted).
+#
+#   MAIN MODE  (HEAD == base tip, i.e. a push to main). "Did main's version actually go up?"
+#     Fails while changesets sit unreleased, and fails if a push changed plugin content
+#     without the version increasing versus the previous commit.
+#
+# WHAT THIS REPLACED, AND WHY:
+#   This script used to compare the working tree against the MERGE BASE in both modes.
+#   That verified "this branch bumped since it forked", not "main's version will increase" —
+#   so a branch forked at 0.26.1 and bumped to 0.26.2 passed even when main had already
+#   reached 0.26.4, and merging it would drag main's version BACKWARDS. The only thing
+#   preventing that was git conflicting on the version lines, which is also precisely the
+#   friction that forced N open PRs to merge serially with one patch version each.
+#   Worse, the main-branch invocation compared main against itself, so it reported
+#   "unchanged" and could never fail: there was no post-merge backstop at all.
 #
 # USAGE:
 #   scripts/check-version-bump.sh [base-ref]
 #     base-ref   git ref to diff against (default: origin/main)
 #
-# Exit 0 = all changed plugins bumped their version FORWARD (or nothing changed).
-# Exit 1 = a plugin changed and its version did not INCREASE (unchanged, or went backwards).
-#
-# NOTE: "increase", not merely "differ". A backwards version is worse than an unchanged
-# one: because propagation is version-keyed, installs sitting on the old higher version
-# silently stop updating until the version climbs back past that high-water mark. This
-# check used a string `=` comparison until 2026-07-27 and cheerfully printed
-# "OK: bumped 0.24.7 -> 0.23.0". A real open PR (#74) would have shipped exactly that.
+# Exit 0 = every changed plugin declares (PR mode) or completed (main mode) a version change.
+# Exit 1 = otherwise.
 
 set -uo pipefail
 
@@ -42,7 +54,20 @@ if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
     exit 0
 fi
 
-MERGE_BASE="$(git merge-base "$BASE_REF" HEAD 2>/dev/null || echo "$BASE_REF")"
+# Pending changesets — the shared signal both modes read.
+shopt -s nullglob
+CHANGESETS=()
+for f in .changes/*.md; do
+    [ "$(basename "$f")" = "README.md" ] && continue
+    CHANGESETS+=("$f")
+done
+
+# Mode detection: on a push to main the workflow passes the branch we are already on.
+if [ "$(git rev-parse HEAD)" = "$(git rev-parse "$BASE_REF")" ]; then
+    MODE="main"
+else
+    MODE="pr"
+fi
 
 version_of() {  # version_of <git-ref-or-WORKING> <path>
     local ref="$1" path="$2" content
@@ -69,49 +94,121 @@ sys.exit(0 if (a is not None and b is not None and a > b) else 1)
 PY
 }
 
-echo "Checking version bumps against $BASE_REF (merge-base ${MERGE_BASE:0:8})..."
+# changeset_names_plugin <plugin> -> exit 0 if some changeset targets it.
+# A changeset with no explicit "plugin:" line targets the default plugin.
+changeset_names_plugin() {
+    local plugin="$1" f explicit found=1
+    for f in "${CHANGESETS[@]:-}"; do
+        [ -f "$f" ] || continue
+        explicit="$(sed -n 's/^plugin:[[:space:]]*//p' "$f" | head -1)"
+        if [ -z "$explicit" ]; then
+            explicit="product-playbook-for-agentic-coding"
+        fi
+        if [ "$explicit" = "$plugin" ]; then found=0; fi
+    done
+    return $found
+}
+
+# ---------------------------------------------------------------------------
+# MAIN MODE — did main's version actually go up?
+# ---------------------------------------------------------------------------
+if [ "$MODE" = "main" ]; then
+    echo "Post-merge check on $(git rev-parse --abbrev-ref HEAD) ($(git rev-parse --short HEAD))..."
+    echo "-------------------------------------------"
+
+    if [ "${#CHANGESETS[@]}" -gt 0 ]; then
+        echo -e "${RED}FAIL: ${#CHANGESETS[@]} unreleased changeset(s) in .changes/${NC}"
+        for f in "${CHANGESETS[@]}"; do echo "       - $f"; done
+        echo ""
+        echo "       Merged content is sitting on main at an unchanged version, which means"
+        echo "       it has reached zero installs (propagation is version-keyed)."
+        echo "       Run: scripts/release.sh && git add -A && git commit -m 'chore: release' && git push"
+        exit 1
+    fi
+
+    PREV="$(git rev-parse --verify --quiet HEAD~1 || true)"
+    if [ -z "$PREV" ]; then
+        echo -e "${GREEN}OK: no previous commit to compare against.${NC}"
+        exit 0
+    fi
+
+    for plugin_json in plugins/*/.claude-plugin/plugin.json; do
+        plugin_dir="$(dirname "$(dirname "$plugin_json")")"
+        name="$(basename "$plugin_dir")"
+
+        if git diff --quiet "$PREV" HEAD -- "$plugin_dir"; then
+            echo -e "${GREEN}OK: $name unchanged in this commit${NC}"
+            continue
+        fi
+
+        cur_version="$(version_of WORKING "$plugin_json" || true)"
+        prev_version="$(version_of "$PREV" "$plugin_json" || echo "")"
+
+        if [ -z "$prev_version" ]; then
+            echo -e "${GREEN}OK: $name is new (version $cur_version)${NC}"
+        elif version_gt "$cur_version" "$prev_version"; then
+            echo -e "${GREEN}OK: $name $prev_version -> $cur_version${NC}"
+        else
+            echo -e "${RED}FAIL: $name changed on main but version did not increase ($prev_version -> $cur_version)${NC}"
+            echo -e "       This content will not reach a single install until the version climbs."
+            FAILURES=$((FAILURES + 1))
+        fi
+    done
+
+    echo ""
+    if [ "$FAILURES" -gt 0 ]; then
+        echo -e "${RED}Post-merge version check FAILED.${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}Post-merge version check PASSED.${NC}"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# PR MODE — does this PR declare a version change?
+# ---------------------------------------------------------------------------
+MERGE_BASE="$(git merge-base "$BASE_REF" HEAD 2>/dev/null || echo "$BASE_REF")"
+
+echo "Checking version declarations against $BASE_REF (merge-base ${MERGE_BASE:0:8})..."
 echo "-------------------------------------------"
 
-shopt -s nullglob
 for plugin_json in plugins/*/.claude-plugin/plugin.json; do
-    plugin_dir="$(dirname "$(dirname "$plugin_json")")"   # plugins/<name>
+    plugin_dir="$(dirname "$(dirname "$plugin_json")")"
     name="$(basename "$plugin_dir")"
 
-    # Did anything under this plugin change vs the merge-base?
     if git diff --quiet "$MERGE_BASE" -- "$plugin_dir"; then
         echo -e "${GREEN}OK: $name unchanged${NC}"
         continue
     fi
 
+    if changeset_names_plugin "$name"; then
+        echo -e "${GREEN}OK: $name changed and declares a changeset${NC}"
+        continue
+    fi
+
+    # Legacy path: a hand bump still satisfies the requirement.
     cur_version="$(version_of WORKING "$plugin_json" || true)"
     base_version="$(version_of "$MERGE_BASE" "$plugin_json" || echo "")"
 
     if [ -z "$base_version" ]; then
         echo -e "${GREEN}OK: $name is new (version $cur_version)${NC}"
-        continue
-    fi
-
-    if [ "$cur_version" = "$base_version" ]; then
-        echo -e "${RED}FAIL: $name changed but version not bumped (still $cur_version)${NC}"
-        echo -e "       Run: scripts/sync-version.sh <new-version> $name"
-        FAILURES=$((FAILURES + 1))
-    elif ! version_gt "$cur_version" "$base_version"; then
-        echo -e "${RED}FAIL: $name version went BACKWARDS ($base_version -> $cur_version)${NC}"
-        echo -e "       Auto-update is version-keyed: installs on $base_version would stop"
-        echo -e "       updating until the version climbs back past $base_version."
-        echo -e "       Run: scripts/sync-version.sh <version greater than $base_version> $name"
-        FAILURES=$((FAILURES + 1))
+    elif version_gt "$cur_version" "$base_version"; then
+        echo -e "${GREEN}OK: $name hand-bumped $base_version -> $cur_version${NC}"
+        echo -e "${YELLOW}     (a changeset is preferred — it cannot conflict with other PRs)${NC}"
     else
-        echo -e "${GREEN}OK: $name bumped $base_version -> $cur_version${NC}"
+        echo -e "${RED}FAIL: $name changed but declares no version change${NC}"
+        echo -e "       Add a changeset (preferred — never conflicts with other open PRs):"
+        echo -e "         .changes/<slug>.md  with  'plugin: $name' and 'bump: patch|minor|major'"
+        echo -e "       See .changes/README.md."
+        FAILURES=$((FAILURES + 1))
     fi
 done
 
 echo ""
 if [ "$FAILURES" -gt 0 ]; then
-    echo -e "${RED}Version-bump check FAILED ($FAILURES plugin(s) without a forward version bump).${NC}"
-    echo "Auto-update is version-keyed: unbumped changes never reach users' installs,"
-    echo "and a backwards version stalls installs already on the higher one."
+    echo -e "${RED}Version-declaration check FAILED ($FAILURES plugin(s)).${NC}"
+    echo "Auto-update is version-keyed: undeclared changes never reach users' installs."
     exit 1
 fi
-echo -e "${GREEN}Version-bump check PASSED.${NC}"
+echo -e "${GREEN}Version-declaration check PASSED.${NC}"
 exit 0

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+#
+# release.sh — Consume .changes/*.md, compute each plugin's new version, update
+#              plugin.json + marketplace.json + CHANGELOG.md, delete the changesets.
+#
+# WHY THIS EXISTS:
+#   The version is a single monotonic counter on main, but PRs are parallel. Requiring
+#   each PR to bump the version made N open PRs mutually exclusive — they all wanted the
+#   same next number — which forced serialized merges (one patch version per PR) and made
+#   every PR's version-file edits conflict with every other PR's.
+#
+#   Changesets move the bump off the PR branch: a PR adds a NEW FILE (cannot conflict),
+#   and the number is computed here, once, on main. Any number of PRs merge in any order.
+#
+# USAGE:
+#   scripts/release.sh [--dry-run]
+#
+# AFTER RUNNING:
+#   git add -A && git commit -m "chore: release <version>" && git push
+#   The version bump is what propagates the update to installs — see CLAUDE.md.
+
+set -euo pipefail
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+
+if [ ! -d ".changes" ] || [ -z "$(find .changes -name '*.md' ! -name 'README.md' -print -quit)" ]; then
+    echo -e "${YELLOW}No changesets in .changes/ — nothing to release.${NC}"
+    exit 0
+fi
+
+# All parsing/merging happens in python: version arithmetic and CHANGELOG assembly are
+# both places where a bash-and-sed version would be quietly wrong.
+PLAN="$(python3 - "$DRY_RUN" <<'PY'
+import json, os, re, sys, datetime, glob
+
+dry = sys.argv[1] == "1"
+RANK = {"patch": 0, "minor": 1, "major": 2}
+DEFAULT_PLUGIN = "product-playbook-for-agentic-coding"
+
+def parse(path):
+    text = open(path).read()
+    meta, body = {}, text
+    m = re.match(r'^---\n(.*?)\n---\n?(.*)$', text, re.S)
+    if m:
+        for line in m.group(1).splitlines():
+            if ':' in line:
+                k, v = line.split(':', 1)
+                meta[k.strip()] = v.strip()
+        body = m.group(2)
+    return meta, body.strip()
+
+changesets = sorted(p for p in glob.glob(".changes/*.md") if os.path.basename(p) != "README.md")
+
+by_plugin = {}
+for path in changesets:
+    meta, body = parse(path)
+    plugin = meta.get("plugin", DEFAULT_PLUGIN)
+    bump = (meta.get("bump") or "patch").lower()
+    if bump not in RANK:
+        print(f"ERROR|invalid bump '{bump}' in {path} (expected patch|minor|major)")
+        sys.exit(1)
+    if not body:
+        print(f"ERROR|{path} has no body — the CHANGELOG prose is the point")
+        sys.exit(1)
+    by_plugin.setdefault(plugin, {"bump": "patch", "entries": [], "files": []})
+    slot = by_plugin[plugin]
+    if RANK[bump] > RANK[slot["bump"]]:
+        slot["bump"] = bump
+    slot["entries"].append(body)
+    slot["files"].append(path)
+
+def bumped(version, kind):
+    major, minor, patch = (int(x) for x in re.match(r'^(\d+)\.(\d+)\.(\d+)', version).groups())
+    if kind == "major":
+        return f"{major + 1}.0.0"
+    if kind == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+# Group entries under their "### Heading" so the CHANGELOG keeps one section per kind
+# rather than repeating "### Fixed" once per merged PR.
+def assemble(entries):
+    sections, order = {}, []
+    for entry in entries:
+        current = "### Changed"
+        for line in entry.splitlines():
+            if line.startswith("###"):
+                current = line.strip()
+                if current not in order:
+                    order.append(current)
+                sections.setdefault(current, [])
+            else:
+                if current not in sections:
+                    sections[current] = []
+                    if current not in order:
+                        order.append(current)
+                sections[current].append(line)
+    out = []
+    for heading in order:
+        lines = sections.get(heading, [])
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        while lines and not lines[-1].strip():
+            lines.pop()
+        if lines:
+            out.append(heading + "\n" + "\n".join(lines))
+    return "\n\n".join(out)
+
+today = datetime.date.today().isoformat()
+released = []
+
+for plugin, slot in sorted(by_plugin.items()):
+    pj = os.path.join("plugins", plugin, ".claude-plugin", "plugin.json")
+    if not os.path.isfile(pj):
+        print(f"ERROR|changeset names unknown plugin '{plugin}' (no {pj})")
+        sys.exit(1)
+    with open(pj) as f:
+        data = json.load(f)
+    old = data["version"]
+    new = bumped(old, slot["bump"])
+    released.append((plugin, old, new, slot["bump"], len(slot["files"])))
+
+    if dry:
+        continue
+
+    data["version"] = new
+    with open(pj, "w") as f:
+        json.dump(data, f, indent=2); f.write("\n")
+
+    market_path = ".claude-plugin/marketplace.json"
+    with open(market_path) as f:
+        market = json.load(f)
+    for entry in market.get("plugins", []):
+        if entry.get("name") == plugin:
+            entry["version"] = new
+    with open(market_path, "w") as f:
+        json.dump(market, f, indent=2); f.write("\n")
+
+    if plugin == DEFAULT_PLUGIN:
+        body = assemble(slot["entries"])
+        with open("CHANGELOG.md") as f:
+            log = f.read()
+        section = f"## [Unreleased]\n\n## [{new}] - {today}\n\n{body}\n"
+        log = log.replace("## [Unreleased]\n", section, 1)
+        with open("CHANGELOG.md", "w") as f:
+            f.write(log)
+
+    for path in slot["files"]:
+        os.remove(path)
+
+for plugin, old, new, kind, count in released:
+    print(f"OK|{plugin}|{old}|{new}|{kind}|{count}")
+PY
+)"
+
+while IFS='|' read -r status a b c d e; do
+    [ -z "$status" ] && continue
+    if [ "$status" = "ERROR" ]; then
+        echo -e "${RED}ERROR: $a${NC}"; exit 1
+    fi
+    if [ "$DRY_RUN" = "1" ]; then
+        echo -e "${YELLOW}(dry run)${NC} $a: $b -> $c  ($d, from $e changeset(s))"
+    else
+        echo -e "${GREEN}Released $a: $b -> $c${NC}  ($d, from $e changeset(s))"
+    fi
+done <<< "$PLAN"
+
+if [ "$DRY_RUN" = "1" ]; then
+    echo ""
+    echo "Dry run — nothing written. Re-run without --dry-run to apply."
+    exit 0
+fi
+
+echo ""
+echo "Next steps:"
+echo "  1. Review the CHANGELOG section and the version files."
+echo "  2. git add -A && git commit -m 'chore: release' && git push"
+echo "     (the version bump is what propagates the update to installs)"

--- a/scripts/test-version-checks.sh
+++ b/scripts/test-version-checks.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+#
+# test-version-checks.sh — Exercise check-version-bump.sh and release.sh in a sandbox repo.
+#
+# WHY THIS EXISTS:
+#   These two scripts are the only thing standing between a merged change and an install
+#   that silently never updates. The previous guard passed a scenario that would drag main's
+#   version BACKWARDS (case 7 below) and its main-branch invocation could never fail at all
+#   (case 5) — both invisible without a test that constructs the situation on purpose.
+#
+# USAGE: scripts/test-version-checks.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+PASS=0; FAIL=0
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+PLUGIN="product-playbook-for-agentic-coding"
+
+# Build a minimal repo with the same shape the real scripts expect.
+new_sandbox() {  # new_sandbox <version>
+    local version="$1" dir="$SANDBOX/repo"
+    rm -rf "$dir"; mkdir -p "$dir/scripts" "$dir/.claude-plugin" "$dir/.changes"
+    mkdir -p "$dir/plugins/$PLUGIN/.claude-plugin" "$dir/plugins/$PLUGIN/commands"
+    cp "$REPO_ROOT/scripts/check-version-bump.sh" "$REPO_ROOT/scripts/release.sh" "$dir/scripts/"
+    chmod +x "$dir/scripts/"*.sh
+    cat > "$dir/plugins/$PLUGIN/.claude-plugin/plugin.json" <<EOF
+{
+  "name": "$PLUGIN",
+  "version": "$version"
+}
+EOF
+    cat > "$dir/.claude-plugin/marketplace.json" <<EOF
+{
+  "name": "test-marketplace",
+  "plugins": [
+    { "name": "$PLUGIN", "source": "./plugins/$PLUGIN", "version": "$version" }
+  ]
+}
+EOF
+    printf '# Changelog\n\n## [Unreleased]\n\n## [%s] - 2026-01-01\n\n### Added\n- seed\n' "$version" > "$dir/CHANGELOG.md"
+    echo "seed" > "$dir/plugins/$PLUGIN/commands/thing.md"
+    git -C "$dir" init -q -b main
+    git -C "$dir" config user.email t@t.t; git -C "$dir" config user.name t
+    git -C "$dir" add -A; git -C "$dir" commit -q -m "seed at $version"
+    echo "$dir"
+}
+
+set_version() {  # set_version <dir> <version>
+    python3 - "$1" "$2" "$PLUGIN" <<'PY'
+import json, sys, os
+d, v, plugin = sys.argv[1], sys.argv[2], sys.argv[3]
+p = os.path.join(d, "plugins", plugin, ".claude-plugin", "plugin.json")
+data = json.load(open(p)); data["version"] = v
+json.dump(data, open(p, "w"), indent=2)
+m = os.path.join(d, ".claude-plugin", "marketplace.json")
+mk = json.load(open(m))
+for e in mk["plugins"]:
+    if e["name"] == plugin: e["version"] = v
+json.dump(mk, open(m, "w"), indent=2)
+PY
+}
+
+changeset() {  # changeset <dir> <slug> <bump> [heading]
+    local heading="${4:-### Fixed}"
+    printf -- '---\nplugin: %s\nbump: %s\n---\n\n%s\n- **%s** — body prose.\n' \
+        "$PLUGIN" "$3" "$heading" "$2" > "$1/.changes/$2.md"
+}
+
+check() {  # check <description> <expected: pass|fail> <dir> [base-ref]
+    local desc="$1" expected="$2" dir="$3" base="${4:-main}" out rc
+    out="$(cd "$dir" && bash scripts/check-version-bump.sh "$base" 2>&1)"; rc=$?
+    local actual="pass"; [ $rc -ne 0 ] && actual="fail"
+    if [ "$actual" = "$expected" ]; then
+        echo -e "${GREEN}PASS${NC} $desc"; PASS=$((PASS+1))
+    else
+        echo -e "${RED}FAIL${NC} $desc (expected $expected, got $actual)"
+        echo "$out" | sed 's/^/       /'
+        FAIL=$((FAIL+1))
+    fi
+}
+
+expect() {  # expect <description> <condition-result-rc>
+    if [ "$1" -eq 0 ]; then
+        echo -e "${GREEN}PASS${NC} $2"; PASS=$((PASS+1))
+    else
+        echo -e "${RED}FAIL${NC} $2"; FAIL=$((FAIL+1))
+    fi
+}
+
+echo "=========================================="
+echo "Version check tests"
+echo "=========================================="
+echo ""
+echo "--- PR mode ---"
+
+# 1. plugin changed, changeset present -> pass
+D="$(new_sandbox 0.26.0)"
+git -C "$D" checkout -q -b feature
+echo "edit" >> "$D/plugins/$PLUGIN/commands/thing.md"
+changeset "$D" "my-fix" patch
+git -C "$D" add -A; git -C "$D" commit -q -m change
+check "plugin changed + changeset -> pass" pass "$D"
+
+# 2. plugin changed, nothing declared -> fail
+D="$(new_sandbox 0.26.0)"
+git -C "$D" checkout -q -b feature
+echo "edit" >> "$D/plugins/$PLUGIN/commands/thing.md"
+git -C "$D" add -A; git -C "$D" commit -q -m change
+check "plugin changed + no declaration -> fail" fail "$D"
+
+# 3. legacy hand bump still accepted
+D="$(new_sandbox 0.26.0)"
+git -C "$D" checkout -q -b feature
+echo "edit" >> "$D/plugins/$PLUGIN/commands/thing.md"
+set_version "$D" 0.26.1
+git -C "$D" add -A; git -C "$D" commit -q -m change
+check "plugin changed + hand bump -> pass (legacy path)" pass "$D"
+
+# 4. no plugin change at all
+D="$(new_sandbox 0.26.0)"
+git -C "$D" checkout -q -b feature
+echo "docs" > "$D/README.md"
+git -C "$D" add -A; git -C "$D" commit -q -m docs
+check "no plugin change -> pass" pass "$D"
+
+echo ""
+echo "--- main mode (the backstop that did not exist before) ---"
+
+# 5. unreleased changesets sitting on main -> fail
+D="$(new_sandbox 0.26.0)"
+echo "edit" >> "$D/plugins/$PLUGIN/commands/thing.md"
+changeset "$D" "pending" patch
+git -C "$D" add -A; git -C "$D" commit -q -m "merged PR"
+check "unreleased changesets on main -> fail" fail "$D"
+
+# 6. plugin changed and version increased -> pass
+D="$(new_sandbox 0.26.0)"
+echo "edit" >> "$D/plugins/$PLUGIN/commands/thing.md"
+set_version "$D" 0.26.1
+git -C "$D" add -A; git -C "$D" commit -q -m release
+check "main: content changed + version up -> pass" pass "$D"
+
+# 7. THE HOLE: plugin changed, version identical -> must fail
+D="$(new_sandbox 0.26.0)"
+echo "edit" >> "$D/plugins/$PLUGIN/commands/thing.md"
+git -C "$D" add -A; git -C "$D" commit -q -m "content at unchanged version"
+check "main: content changed + version SAME -> fail" fail "$D"
+
+# 8. plugin changed, version went backwards -> must fail
+D="$(new_sandbox 0.26.4)"
+echo "edit" >> "$D/plugins/$PLUGIN/commands/thing.md"
+set_version "$D" 0.26.2
+git -C "$D" add -A; git -C "$D" commit -q -m "backwards"
+check "main: content changed + version BACKWARDS -> fail" fail "$D"
+
+echo ""
+echo "--- release.sh ---"
+
+# 9. highest bump type wins across changesets; CHANGELOG written; changesets consumed
+D="$(new_sandbox 0.26.0)"
+changeset "$D" "a-fix" patch "### Fixed"
+changeset "$D" "b-feature" minor "### Added"
+(cd "$D" && bash scripts/release.sh >/dev/null 2>&1)
+V="$(python3 -c "import json;print(json.load(open('$D/plugins/$PLUGIN/.claude-plugin/plugin.json'))['version'])")"
+[ "$V" = "0.27.0" ]; expect $? "release: patch+minor -> minor bump (0.26.0 -> 0.27.0, got $V)"
+MV="$(python3 -c "import json;print([p for p in json.load(open('$D/.claude-plugin/marketplace.json'))['plugins'] if p['name']=='$PLUGIN'][0]['version'])")"
+[ "$MV" = "$V" ]; expect $? "release: marketplace.json kept in sync ($MV)"
+grep -q "## \[0.27.0\]" "$D/CHANGELOG.md"; expect $? "release: CHANGELOG section added"
+grep -q "a-fix" "$D/CHANGELOG.md" && grep -q "b-feature" "$D/CHANGELOG.md"
+expect $? "release: both changeset bodies folded into CHANGELOG"
+[ "$(grep -c '^### Added' "$D/CHANGELOG.md")" -ge 1 ] && [ "$(grep -c '^### Fixed' "$D/CHANGELOG.md")" -ge 1 ]
+expect $? "release: entries grouped under their own headings"
+[ -z "$(find "$D/.changes" -name '*.md' ! -name 'README.md')" ]
+expect $? "release: changesets consumed"
+grep -q "## \[Unreleased\]" "$D/CHANGELOG.md"; expect $? "release: Unreleased header preserved"
+
+# 10. major beats minor
+D="$(new_sandbox 1.2.3)"
+changeset "$D" "c-break" major "### Changed"
+changeset "$D" "d-fix" patch "### Fixed"
+(cd "$D" && bash scripts/release.sh >/dev/null 2>&1)
+V="$(python3 -c "import json;print(json.load(open('$D/plugins/$PLUGIN/.claude-plugin/plugin.json'))['version'])")"
+[ "$V" = "2.0.0" ]; expect $? "release: major wins (1.2.3 -> 2.0.0, got $V)"
+
+# 11. dry run changes nothing
+D="$(new_sandbox 0.26.0)"
+changeset "$D" "e-fix" patch
+BEFORE="$(git -C "$D" status --porcelain; cat "$D/plugins/$PLUGIN/.claude-plugin/plugin.json")"
+(cd "$D" && bash scripts/release.sh --dry-run >/dev/null 2>&1)
+AFTER="$(git -C "$D" status --porcelain; cat "$D/plugins/$PLUGIN/.claude-plugin/plugin.json")"
+[ "$BEFORE" = "$AFTER" ]; expect $? "release --dry-run: nothing written"
+
+# 12. release then main-mode check passes end to end
+D="$(new_sandbox 0.26.0)"
+echo "edit" >> "$D/plugins/$PLUGIN/commands/thing.md"
+changeset "$D" "f-fix" patch
+git -C "$D" add -A; git -C "$D" commit -q -m "merged PR"
+(cd "$D" && bash scripts/release.sh >/dev/null 2>&1)
+git -C "$D" add -A; git -C "$D" commit -q -m "chore: release"
+check "release -> main check green end to end" pass "$D"
+
+# 13. no changesets at all is a no-op, not an error
+D="$(new_sandbox 0.26.0)"
+(cd "$D" && bash scripts/release.sh >/dev/null 2>&1); expect $? "release: no changesets -> exit 0"
+
+# 14. invalid bump type is rejected
+D="$(new_sandbox 0.26.0)"
+changeset "$D" "bad" enormous
+(cd "$D" && bash scripts/release.sh >/dev/null 2>&1); [ $? -ne 0 ]
+expect $? "release: invalid bump type rejected"
+
+echo ""
+echo "=========================================="
+echo -e "Passed: ${GREEN}$PASS${NC}   Failed: ${RED}$FAIL${NC}"
+echo "=========================================="
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Root cause of the stacked-bump friction you've hit on every multi-PR merge — and a latent correctness bug underneath it.

## Root cause

**The version is a single monotonic counter on `main`, but PRs are parallel writers.** Requiring each PR to advance it before merge makes N open PRs mutually exclusive — they all want the same next number. That's what forced serialized merges, one patch version per PR:

- 2026-07-17 — 4 PRs → 0.22.1 … 0.22.4
- 2026-07-26 — 9 PRs → 0.23.0 … 0.24.3
- 2026-08-04 — 4 PRs → 0.26.1 … 0.26.4

…and made every PR's version-file edits conflict with every other PR's.

## The part that isn't just friction

`check-version-bump.sh` compared the working tree against the **merge base**. That verifies *"did this branch bump since it forked"*, not *"will main's version increase"*. Verified empirically in a scratch clone:

- Branch forked at `0.26.1`, content change, bumped to `0.26.2`
- `main` meanwhile at `0.26.4`
- **Guard verdict: PASSED** — and merging it sets main's version *backwards* to 0.26.2

That's the exact failure the script's own header warns about ("a backwards version is worse than an unchanged one"). The only thing actually preventing it was **git conflicting on the version lines** — so the friction everyone wanted removed was doing load-bearing safety work nobody designed. Remove the conflicts naively and you'd have shipped the bug.

Second finding: the **push-to-`main` guard run is vacuous**. It computes `merge-base(main, HEAD)` where `HEAD == main`, so it compares main against itself and reports "unchanged" every time. It cannot fail under any input. There was no post-merge backstop at all.

`main` is also not branch-protected (no required checks, no "must be up to date"), so nothing else was catching this.

## Fix

**1. Changesets — remove the shared-counter contention.** A PR adds `.changes/<slug>.md` declaring `bump: patch|minor|major` plus its CHANGELOG prose. A new file per PR **cannot conflict**. Merge order is free.

**2. `scripts/release.sh` — compute the number once, on `main`.** Consumes the changesets, highest bump type wins, updates `plugin.json` + `marketplace.json` + `CHANGELOG.md`, deletes the consumed files. `--dry-run` previews.

**3. Two-mode guard — check what actually matters.**
- **PR mode**: the changed plugin must declare a changeset (a hand bump still passes, with a nudge, so in-flight PRs don't break).
- **main mode**: fails while changesets sit unreleased, **and** fails if plugin content changed without the version increasing versus the previous commit — a real backstop that catches a duplicate or backwards version however it arrived.

## New workflow

Merge every PR in any order (all green, no conflicts), then once:

```bash
scripts/release.sh && git add -A && git commit -m "chore: release" && git push
```

**`main` is red between the first merge and the release.** That's deliberate — it's the forcing function. Content sitting on `main` at an unchanged version has reached zero installs, which is precisely the silent failure this repo was built to prevent. Now it's loud. (Note this PR itself carries an unreleased changeset, so main will go red the moment it merges until the release lands — I can run that immediately after.)

## Verification

`scripts/test-version-checks.sh` — **20/20 pass** in a sandbox repo, including the two cases the old guard was structurally blind to:

| Case | Old guard | New guard |
|---|---|---|
| content merged at unchanged version on main | passed (vacuous) | **fails** |
| version moves backwards on main | passed | **fails** |
| unreleased changesets on main | n/a | **fails** |
| PR declares changeset | n/a | passes |
| PR changes plugin, declares nothing | fails | fails |
| PR hand-bumps (legacy) | passes | passes |

Plus release-side coverage: bump-type precedence (patch+minor→minor, major beats all), marketplace sync, CHANGELOG assembly and heading grouping, changeset consumption, `--dry-run` inertness, invalid bump rejection, and a merge→release→green end-to-end.

Also: `validate-plugin.sh` PASSED (0 errors / 0 warnings); this PR's own changeset satisfies the new PR-mode check.

## Also updated

- **CLAUDE.md** — "stacked bumps" section replaced with the changeset flow and the why
- **`/playbook:merge-prs`** — Step 0.5 now classifies repos as changeset-style vs bump-in-PR style; changeset repos skip per-PR versions and run one release at the end (new Step 5.9). Step 5.6 learned that server-side branch auto-delete is **asynchronous** — observed during today's run, where a branch looked like it survived and had simply not been reaped yet.
- **README** — Hooks & Checks table gains both scripts

`scripts/sync-version.sh` is untouched and still works for a manual or emergency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)