### PR TITLE
docs: give the CLI path for updating an install, not just the /plugin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,20 +66,32 @@ This plugin also uses a marketplace-embedded structure (plugin source is a relat
 inside the marketplace repo), so a machine may need a marketplace refresh to pull a new
 version, and the "Update now" button on the *plugin* won't work directly.
 
-**To pull the latest version onto a machine:**
+**To pull the latest version onto a machine** — two steps, because the marketplace clone
+and the plugin install are refreshed separately:
 
-1. **Refresh the marketplace** (pulls latest from GitHub):
-   ```
-   /plugin → Marketplaces tab → select "product-playbook-marketplace" → Update now
-   ```
+```bash
+claude plugin marketplace update product-playbook-marketplace
+claude plugin update product-playbook-for-agentic-coding@product-playbook-marketplace
+```
 
-2. **Reinstall the plugin** if it didn't refresh to the new version automatically:
-   ```
-   /plugin → Installed tab → select the plugin → Uninstall
-   /plugin → Marketplaces tab → select marketplace → Install
-   ```
+**Use `update`, not `install`.** On an already-installed plugin, `claude plugin install`
+short-circuits with *"already installed"* and does **not** upgrade — it can leave the new
+version's files sitting in `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`
+while the install still points at the old one. `update` is the subcommand that moves the
+pointer. Never hand-edit `installed_plugins.json`.
 
-You can confirm the live version under `/plugin → Installed`.
+The update applies on **restart** — a session already running keeps the version it loaded.
+Confirm with `claude plugin list`, or under `/plugin → Installed`.
+
+<details>
+<summary>Equivalent via the <code>/plugin</code> UI</summary>
+
+1. **Refresh the marketplace**: `/plugin` → Marketplaces tab → select
+   "product-playbook-marketplace" → Update now
+2. **Reinstall the plugin** if it didn't refresh automatically: `/plugin` → Installed tab →
+   select the plugin → Uninstall, then Marketplaces tab → select marketplace → Install
+
+</details>
 
 **Note:** The "Local plugins cannot be updated remotely" message appears because the
 plugin uses a relative path source within the marketplace. This is the same pattern used


### PR DESCRIPTION
Found while syncing this machine from 0.25.2 → 0.26.0 earlier today. README documented the refresh as a `/plugin` UI operation only, which an agent or a scripted setup can't drive.

## The CLI path

```bash
claude plugin marketplace update product-playbook-marketplace
claude plugin update product-playbook-for-agentic-coding@product-playbook-marketplace
```

## The sharp edge worth documenting

**`claude plugin install` does not upgrade an already-installed plugin.** It short-circuits with *"already installed (scope: user)"* — but by then the marketplace refresh has already materialised the new version's files at `~/.claude/plugins/cache/<marketplace>/<plugin>/0.26.0/`, while `installed_plugins.json` still points at `.../0.25.2`.

So the install *looks* done — new files are on disk, no error — and isn't. `claude plugin update` is the subcommand that moves the pointer:

```
✔ Plugin "product-playbook-for-agentic-coding" updated from 0.25.2 to 0.26.0 for scope user. Restart to apply changes.
```

That's a close cousin of the failure mode this repo already guards against: a change that appears shipped while every install stays on the old copy.

Also documents that the update applies on **restart** — a session already running keeps the version it loaded, which matters when you ship a command and then try to use it in the same session.

The `/plugin` UI steps are kept, in a collapsed `<details>` block.

## Verification

- Both commands run against this machine, taking the live install 0.25.2 → 0.26.0 (`gitCommitSha` now `472aff81`)
- `scripts/validate-plugin.sh` — PASSED, 0 errors / 0 warnings
- `scripts/check-version-bump.sh origin/main` — PASSED. No changeset: this changes only the repo README, nothing under `plugins/`, so there is nothing to propagate and no version bump is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)